### PR TITLE
Add line-height fix to headers.

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -344,6 +344,7 @@ article li {
 h1, h2, h3, h4, h5 { 
     font-family: Quattrocento, Times, serif;
     margin: 10px 0;
+    line-height: 140%;
     }
 h1 { margin: 3px 0px -5px; font-size: 23px;}
 


### PR DESCRIPTION
`line-height: 140%` is a typography shortcut that improves readability. @yyjhao committed this in 3205ffd at my request. This commit adds it for headers.