### PR TITLE
Add link to about page in "hacker" in front page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,7 +2,7 @@
 <main class="row front-page main">
   <section class="section col-12 hero">
     <h1 class="hero-title">
-      Spreading the <span class="hero-hacker">hacker</span> culture
+      Spreading the <a href="https://www.nushackers.org/hackerdefined/" class="hero-hacker">hacker</span> culture
     </h1>
     <ul class="list row justify-content-around">
       {{ range $event := $.Site.Data.projects.projects }}


### PR DESCRIPTION
It looks like a link anyways with the underscore and the different color. Might as well make it a link?