### PR TITLE
Remove hardcoded nushackers.org domain in hrefs

### DIFF
--- a/data/projects.yml
+++ b/data/projects.yml
@@ -1,7 +1,7 @@
 projects:
   - name: Friday Hacks
     description: Interesting talks for hackers from all walks of life
-    url: //www.nushackers.org/fridayhacks
+    url: /fridayhacks
     logo: static/img/friday-hacks-logo.svg
   - name: hackerschool
     description: Hacking workshops for everyone

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,7 +2,7 @@
 <main class="row front-page main">
   <section class="section col-12 hero">
     <h1 class="hero-title">
-      Spreading the <a href="https://www.nushackers.org/hackerdefined/" class="hero-hacker">hacker</a> culture
+      Spreading the <a href="/hackerdefined/" class="hero-hacker">hacker</a> culture
     </h1>
     <ul class="list row justify-content-around">
       {{ range $event := $.Site.Data.projects.projects }}


### PR DESCRIPTION
The Friday Hacks and "Spreading the *hacker* culture" links had hardcoded domains, which leads to the wrong redirect in dev.