### PR TITLE
CI passes even when build fails (DON'T MERGE)

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,3 +1,4 @@
+{{ fail }}
 {{ define "main" }}
 <main class="row front-page main">
   <section class="section col-12 hero">

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,5 +3,5 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.30.2"
+  HUGO_VERSION = "0.54.0"
   YARN_VERSION = "1.3.2"


### PR DESCRIPTION
The Netlify deploy #215 actually [failed](https://app.netlify.com/sites/nushackers/deploys/5c83e726d488c30008edc1d8) &mdash; https://deploy-preview-215--nushackers.netlify.com/, but somehow it still shows up as a successful build in Netlify.