### PR TITLE
Fix netlify deploy preview `baseUrl`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,6 @@
 [build.environment]
   HUGO_VERSION = "0.92.0"
   YARN_VERSION = "1.22.17"
+
+[context.deploy-preview]
+  command = "yarn run build -b $DEPLOY_PRIME_URL"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Sup! This is the source code of the nushackers blog site http://nushackers.org.",
     "license": "MIT",
     "scripts": {
-        "build": "hugo",
+        "build": "hugo --gc",
         "dev": "hugo serve"
     },
     "devDependencies": {


### PR DESCRIPTION
- Override hugo `baseUrl` for deploy previews
- Add `--gc` flag for cleanup