### PR TITLE
Add sign up links to Hackerschool and Hacker Toolbox

### DIFF
--- a/layouts/partials/projects/hackerschool_li.html
+++ b/layouts/partials/projects/hackerschool_li.html
@@ -1,13 +1,10 @@
 <li class="events-item item">
   <h3 class=hs-topic>{{ .event.topic }}</h3>
-  {{- if ne .event.blog_post nil -}}
-    <a href="{{ .event.blog_post }}">
+  {{- if ne .event.sign_up nil -}}
+    <a href="{{ .event.sign_up }}">
   {{- end -}}
-  <time class="hs-time" datetime={{ dateFormat "2006-01-02T15:04:05-07:00" .event.date}}>
+  <time class="hs-time" datetime={{ dateFormat "2006-01-02T15:04:05-07:00" .event.date }}>
     {{ dateFormat "Mon, Jan 2, 3:04pm" (time .event.date) }}
   </time>
-  {{- if ne .event.blog_post nil -}}
-    </a>
-  {{- end -}}
   <address class="events-address">{{ .event.venue }}</address>
 </li>

--- a/layouts/partials/projects/hackerstoolbox_li.html
+++ b/layouts/partials/projects/hackerstoolbox_li.html
@@ -1,14 +1,11 @@
 <li class="events-item item">
   <h3 class=hs-topic>{{ .event.topic }}</h3>
-  {{- if ne .event.blog_post nil -}}
-    <a href="{{ .event.blog_post }}">
+  {{- if ne .event.sign_up nil -}}
+    <a href="{{ .event.sign_up }}">
   {{- end -}}
   <time class="hs-time" datetime={{ dateFormat "2006-01-02T15:04:05-07:00" .event.date}}>
     {{ dateFormat "Mon, Jan 2, 3:04pm" (time .event.date) }}
   </time>
-  {{- if ne .event.blog_post nil -}}
-    </a>
-  {{- end -}}
   {{- if ne .event.venue nil -}}
   <address class="events-address">{{ .event.venue }}</address>
   {{- end -}}


### PR DESCRIPTION
Currently all Hackerschool and Hacker Toolbox events on our websites do not have any way for people to sign up. This PR changes the previous `blog_post` data field to a `sign_up` field.

```yaml
events:
  - topic: Unity for Beginners
    venue: Seminar Room 11 @ COM3-01-20
    sign_up: <sign-up-link>
    date: 2023-08-30T19:00:00
```