### PR TITLE
add taxonomy layout

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,0 +1,13 @@
+{{ define "main" }}
+<div class="container">
+  <div class="row">
+    <div>
+      {{ range .Pages }}
+      <h3>
+        <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+      </h3>
+      {{ end }}
+    </div>
+  </div>
+</div>
+{{ end }}


### PR DESCRIPTION
Fixes #666

Only super old posts are categorised, maybe we backfill the posts (clean up some categories as well) and expose somewhere on the landing page.