### PR TITLE
feat: Pagefind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ typings/
 
 # IDE
 .idea/
+
+# Local Netlify folder
+.netlify

--- a/README.md
+++ b/README.md
@@ -10,15 +10,24 @@ To get started, you'll need:
 1. [Hugo v0.111.3 (the extended version)](https://github.com/gohugoio/hugo/releases/tag/v0.111.3)
 2. Yarn v1 with a recent version of NodeJS
 
-Then clone this repository and run
+To set up
+1. Clone this repository and install dependencies
+    ```bash
+    git clone https://github.com/nushackers/nushackers-site.git
+    yarn install # install dependencies
+    ```
+2. Start Development Server (with Live Reload)
+    ```bash
+    yarn dev # start dev server at localhost:1313
+    ```
+3. (Alternate): Serve Build (with pagefind)
+    ```bash
+    yarn full-dev # serve public build at http://localhost:1414
+    ```
 
-```bash
-yarn install # install dependencies
-yarn dev # start development server
-```
+Note that `yarn dev` starts a dev server at <http://localhost:1313>, where hugo watches and updates the site when any changes are made. 
 
-Hugo will now generate the site and watch the directory and update the site when
-any changes are made. You can access the site at <http://localhost:1313>.
+`yarn full-dev` runs [pagefind](https://github.com/CloudCannon/pagefind) on all pages, then serves the full build on <http://localhost:1414>, where is is **NO** live reload.
 
 ## Data Management 📊
 

--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -32,8 +32,19 @@
     font-size: 0.9rem;
 
     @extend .clear-list;
-    @include media-breakpoint-up(sm) {
+
+    @media (max-width: 576px) {
+      justify-content: center !important;
+    }
+
+    @include media-breakpoint-down(sm) {
       font-size: 1rem;
+      max-width: 400px;
+      width: 100%;
+      margin: 0 auto;
+      margin-top: 0.2rem;
+      justify-content: left;
+      gap: 0.2rem;
     }
     @include media-breakpoint-up(lg) {
       font-size: 1.25rem;
@@ -61,6 +72,11 @@
     padding: 0.3rem 0.4rem 0.1rem;
     text-decoration: none;
     color: black;
+
+    .search-text {
+      display: none;
+      padding-right: 0.2rem;
+    }
 
     @include media-breakpoint-up(md) {
       padding: 0.4rem 0.5rem 0.2rem;

--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -47,8 +47,13 @@
       gap: 0.2rem;
     }
     @include media-breakpoint-up(lg) {
+      font-size: 1.2rem; // reduce text size to ensure single line navbar
+    }
+    @include media-breakpoint-up(xl) {
       font-size: 1.25rem;
     }
+
+    
   }
   .nav-menu-item {
     position: relative;

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -25,6 +25,7 @@ body {
   animation-duration: 295ms;
   animation-timing-function: $standard-curve;
   animation-name: fade-up;
+  position: relative;
 }
 
 @keyframes fade-up {
@@ -76,3 +77,4 @@ body {
 @import "./front-page.scss";
 @import "./articles.scss";
 @import "./paginate.scss";
+@import "./search.scss";

--- a/assets/scss/search.scss
+++ b/assets/scss/search.scss
@@ -88,12 +88,13 @@ $link-hover-color: $hackers-orange;
 
   .pagefind-ui__results-area {
     max-height: 90vh !important;
+    padding-bottom: 1rem !important;
     overflow-y: auto !important;
     overscroll-behavior: contain !important;
   }
 
   .pagefind-ui__results {
-    padding-bottom: 2rem !important;
+    padding: 1rem !important;
   }
   
   .pagefind-ui__button {

--- a/assets/scss/search.scss
+++ b/assets/scss/search.scss
@@ -87,18 +87,18 @@ $link-hover-color: $hackers-orange;
   }
 
   .pagefind-ui__results-area {
-    max-height: 90vh !important;
-    padding-bottom: 1rem !important;
+    max-height: calc(90dvh - 2rem) !important;
+    margin-bottom: 2rem !important;
     overflow-y: auto !important;
     overscroll-behavior: contain !important;
   }
 
   .pagefind-ui__results {
-    padding: 1rem !important;
+    padding-bottom: 1rem !important;
   }
   
   .pagefind-ui__button {
-    margin-bottom: 2rem !important;
+    margin-bottom: 1rem !important;
   }
 }
 

--- a/assets/scss/search.scss
+++ b/assets/scss/search.scss
@@ -1,0 +1,84 @@
+$hackers-orange: #e66000;
+$highlight-orange: #f8941d;
+$button-link-color: #4a4a4a;
+$link-color: $hackers-orange;
+$link-hover-color: $hackers-orange;
+
+@import "./animation.scss";
+
+.search-section {
+  position: absolute;
+  background: white;
+  padding: 1rem;
+  border-radius: 0 0 4px 4px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+
+  animation-duration: 150ms;
+  animation-timing-function: $standard-curve;
+  animation-name: fade-up;
+
+  &.fade-out {
+    animation-duration: 150ms;
+    animation-timing-function: $standard-curve;
+    animation-name: fade-down;
+    pointer-events: none;
+  }
+
+  .pagefind-ui {
+    --pagefind-ui-scale: 0.8;
+    --pagefind-ui-primary: #e66000;
+    --pagefind-ui-text: #000;
+    --pagefind-ui-background: #fff;
+    --pagefind-ui-border: #e66000;
+    --pagefind-ui-border-width: 1px;
+  }
+
+  .pagefind-ui__search-input {
+    width: 100%;
+    margin-bottom: 1rem;
+  }
+
+  .pagefind-ui__search-input:focus {
+    outline: 1.5px solid #f8941d; 
+  }
+
+  .pagefind-ui__results-area {
+    max-height: 70vh;
+    overflow-y: auto;
+  }
+}
+
+@media (max-width: 768px) {
+  #search {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    max-width: 100%;
+    height: 100vh;
+    border-radius: 0;
+  }
+}
+
+@keyframes fade-up {
+  from {
+    opacity: 0.25;
+    transform: translateY(0.3rem);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes fade-down {
+  from {
+    opacity: 1;
+    transform: none;
+  }
+  to {
+    opacity: 0;
+    transform: translateY(0.3rem);
+  }
+}

--- a/assets/scss/search.scss
+++ b/assets/scss/search.scss
@@ -90,9 +90,13 @@ $link-hover-color: $hackers-orange;
     max-height: 90vh !important;
     overflow-y: auto !important;
   }
+
+  .pagefind-ui__results {
+    padding-bottom: 2rem !important;
+  }
   
   .pagefind-ui__button {
-    margin-bottom: 10vh !important;
+    margin-bottom: 2rem !important;
   }
 }
 

--- a/assets/scss/search.scss
+++ b/assets/scss/search.scss
@@ -55,7 +55,7 @@ $link-hover-color: $hackers-orange;
     border: none;
     font-size: 24px;
     position: absolute;
-    right: 1rem;
+    right: 1.5rem;
     top: 1rem;
     color: $button-link-color;
     cursor: pointer;
@@ -63,7 +63,13 @@ $link-hover-color: $hackers-orange;
   }
 }
 
-@media (max-width: 768px) {
+@include media-breakpoint-down(sm) {
+  .search-text {
+    display: inline !important; // show search text
+  }
+}
+
+@media (max-width: 576px) {
   #search {
     position: fixed;
     top: 0;

--- a/assets/scss/search.scss
+++ b/assets/scss/search.scss
@@ -89,6 +89,7 @@ $link-hover-color: $hackers-orange;
   .pagefind-ui__results-area {
     max-height: 90vh !important;
     overflow-y: auto !important;
+    overscroll-behavior: contain !important;
   }
 
   .pagefind-ui__results {

--- a/assets/scss/search.scss
+++ b/assets/scss/search.scss
@@ -98,7 +98,7 @@ $link-hover-color: $hackers-orange;
   }
   
   .pagefind-ui__button {
-    margin-bottom: 1rem !important;
+    margin-bottom: 2rem !important;
   }
 }
 

--- a/assets/scss/search.scss
+++ b/assets/scss/search.scss
@@ -47,6 +47,20 @@ $link-hover-color: $hackers-orange;
     max-height: 70vh;
     overflow-y: auto;
   }
+
+  .mobile-search-exit {
+    display: none;
+    z-index: 9999;
+    background: none;
+    border: none;
+    font-size: 24px;
+    position: absolute;
+    right: 1rem;
+    top: 1rem;
+    color: $button-link-color;
+    cursor: pointer;
+    padding: 0.5rem;
+  }
 }
 
 @media (max-width: 768px) {
@@ -56,8 +70,29 @@ $link-hover-color: $hackers-orange;
     left: 0;
     right: 0;
     max-width: 100%;
-    height: 100vh;
+    height: 100%;
     border-radius: 0;
+  }
+
+  .mobile-search-exit {
+    display: block !important;
+  }
+
+  .pagefind-ui__search-input {
+    padding-right: 5rem !important;
+  }
+
+  .pagefind-ui__search-clear {
+    display: none !important;
+  }
+
+  .pagefind-ui__results-area {
+    max-height: 90vh !important;
+    overflow-y: auto !important;
+  }
+  
+  .pagefind-ui__button {
+    margin-bottom: 10vh !important;
   }
 }
 

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -1,10 +1,13 @@
 {{ define "main" }}
 <main class="container main">
+  {{ partial "search.html" . }}
   <section class="row justify-content-center section">
+    <a hidden data-pagefind-sort="date">2099-01-01</a>
+
     {{ if .Pages }}
-    <article class="col-12 col-md-8">
+    <article class="col-12 col-md-8" data-pagefind-body>
         <header class="section-header">
-            <h1 class="section-title">{{ .Title }}</h1>
+            <h1 data-pagefind-meta="title" class="section-title">{{ .Title }}</h1>
         </header>
         <div class="section-content">
             {{ .Content }}
@@ -16,9 +19,9 @@
       {{ end }}
     </aside>
     {{ else }}
-    <article class="col-12 col-md-10">
+    <article class="col-12 col-md-10" data-pagefind-body>
         <header class="section-header">
-            <h1 class="section-title">{{ .Title }}</h1>
+            <h1 data-pagefind-meta="title" class="section-title">{{ .Title }}</h1>
         </header>
         <div class="section-content">
             {{ .Content }}
@@ -27,4 +30,9 @@
     {{ end }}
   </section>
 </main>
+{{ end }}
+
+{{ define "scripts" }}
+<script src="/pagefind/pagefind-ui.js" type="text/javascript"></script>
+<script>{{ readFile "static/js/search.js" | safeJS }}</script>
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,7 @@
 {{ define "main" }}
 <main class="row front-page main">
+{{ partial "search.html" . }}
+
   <section class="section col-12 hero">
     <h1 class="hero-title">
       Spreading the
@@ -88,4 +90,6 @@
 {{ end }}
 {{ define "scripts" }}
 <script>{{ readFile "static/js/toggleShowMore.js" | safeJS }}</script>
+<script src="/pagefind/pagefind-ui.js" type="text/javascript"></script>
+<script>{{ readFile "static/js/search.js" | safeJS }}</script>
 {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,9 +8,13 @@
 {{ $postcss_options := dict "config" "postcss.config.js" "noMap" true }}
 {{ $scss := resources.Get "scss/main.scss" }}
 {{ $style := $scss | resources.ToCSS $scss_options | resources.PostCSS $postcss_options | resources.Fingerprint }}
+
 <link rel="preload" href="{{ $style.RelPermalink }}" as="style">
+<link rel="preload" href="/pagefind/pagefind-ui.css" as="style">
 <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Rubik:400,500">
 <link rel="stylesheet" href="{{ $style.RelPermalink }}">
+<link rel="stylesheet" href="/pagefind/pagefind-ui.css">
+
 {{ if .IsHome }}
 {{ range $event := $.Site.Data.events.events }}
 <link rel="dns-prefetch" href="{{ $event.url }}"/>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,9 +8,11 @@
       {{ range .Site.Menus.main }}
       <li class="nav-menu-item{{ if in $currentURL .URL }} nav-menu-active{{ end }}"><a class="nav-menu-link" href="{{ .URL }}">{{ .Name }}</a></li>
       {{ end }}
+
       <li class="nav-menu-item">
-        <a class="nav-menu-link" href="/search" aria-label="Search">
-          <svg xmlns="http://www.w3.org/2000/svg" width=20 height=20 viewBox="0 0 512 512"><path d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM208 352a144 144 0 1 0 0-288 144 144 0 1 0 0 288z"/></svg>
+        <a class="nav-menu-link search-toggle" id='search-toggle' aria-label="Search">
+            <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 512 512"><path d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM208 352a144 144 0 1 0 0-288 144 144 0 1 0 0 288z"/></svg>
+            <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 384 512" style="display: none;"><path d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"/></svg>
         </a>
       </li>
     </ul>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,6 +8,11 @@
       {{ range .Site.Menus.main }}
       <li class="nav-menu-item{{ if in $currentURL .URL }} nav-menu-active{{ end }}"><a class="nav-menu-link" href="{{ .URL }}">{{ .Name }}</a></li>
       {{ end }}
+      <li class="nav-menu-item">
+        <a class="nav-menu-link" href="/search" aria-label="Search">
+          <svg xmlns="http://www.w3.org/2000/svg" width=20 height=20 viewBox="0 0 512 512"><path d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM208 352a144 144 0 1 0 0-288 144 144 0 1 0 0 288z"/></svg>
+        </a>
+      </li>
     </ul>
   </nav>
 </header>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,6 +11,7 @@
 
       <li class="nav-menu-item">
         <a class="nav-menu-link search-toggle" id='search-toggle' aria-label="Search">
+          <span class="search-text">Search</span>
             <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 512 512"><path d="M416 208c0 45.9-14.9 88.3-40 122.7L502.6 457.4c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L330.7 376c-34.4 25.2-76.8 40-122.7 40C93.1 416 0 322.9 0 208S93.1 0 208 0S416 93.1 416 208zM208 352a144 144 0 1 0 0-288 144 144 0 1 0 0 288z"/></svg>
             <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 384 512" style="display: none;"><path d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"/></svg>
         </a>

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,1 +1,3 @@
-<section class="search-section col-12" id="search" style="display: none"></section>
+<section class="search-section col-12" id="search" style="display: none">
+  <button class="mobile-search-exit" aria-label="Close search">×</button>
+</section>

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,0 +1,1 @@
+<section class="search-section col-12" id="search" style="display: none"></section>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,10 +1,16 @@
 {{ define "main" }}
-<main class="row justify-content-center single main">
+<main class="row justify-content-center single main" data-pagefind-body>
+  {{ partial "search.html" . }}
   <section class="col-12 col-md-8 section">
     <article>
-      <h1>{{ .Title }}</h1>
+      <h1 data-pagefind-meta="title">{{ .Title }}</h1>
       <h2 class="posted">Posted on
-        <time>{{ .Date.Format "Jan 2" }}</time> by {{ .Params.author }}
+        <time
+          data-pagefind-sort="date[datetime]"
+          datetime="{{ .Date.Format "2006-01-02	" }}" pubdate>
+            {{ .Date.Format "Jan 2" }}
+        </time> 
+        by {{ .Params.author }}
       </h2>
       {{ .Content }}
       {{ if (.Params.sponsors) }}
@@ -64,4 +70,6 @@
 {{ define "scripts" }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
   integrity="sha384-Ra6zh6uYMmH5ydwCqqMoykyf1T/+ZcnOQfFPhDrp2kI4OIxadnhsvvA2vv9A7xYv" crossorigin="anonymous"></script>
+<script src="/pagefind/pagefind-ui.js" type="text/javascript"></script>
+<script>{{ readFile "static/js/search.js" | safeJS }}</script>
 {{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,4 +7,4 @@
   YARN_VERSION = "1.22.17"
 
 [context.deploy-preview]
-  command = "yarn run build -b $DEPLOY_PRIME_URL"
+  command = "yarn run partial-build -b $DEPLOY_PRIME_URL && npx pagefind --site public --output-subdir pagefind"

--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
     "description": "Sup! This is the source code of the nushackers blog site http://nushackers.org.",
     "license": "MIT",
     "scripts": {
-        "build": "hugo --gc && npx pagefind --site public --output-subdir pagefind",
+        "build": "hugo --gc && pagefind --site public --output-subdir pagefind",
         "partial-build": "hugo --gc",
         "dev": "hugo server",
-        "full-dev": "hugo --gc && npx pagefind --site public --serve"
+        "full-dev": "hugo --gc && pagefind --site public --serve"
     },
     "devDependencies": {
         "bootstrap": "^4.6.1",
         "postcss": "^8.4.5",
         "postcss-assets": "^6.0.0",
-        "postcss-cli": "^9.1.0"
+        "postcss-cli": "^9.1.0",
+        "pagefind": "1.3.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
     "description": "Sup! This is the source code of the nushackers blog site http://nushackers.org.",
     "license": "MIT",
     "scripts": {
-        "build": "hugo --gc",
-        "dev": "hugo server"
+        "build": "hugo --gc && npx pagefind --site public",
+        "dev": "hugo server",
+        "full-dev": "hugo --gc && npx pagefind --site public --serve"
     },
     "devDependencies": {
         "bootstrap": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "description": "Sup! This is the source code of the nushackers blog site http://nushackers.org.",
     "license": "MIT",
     "scripts": {
-        "build": "hugo --gc && npx pagefind --site public",
+        "build": "hugo --gc && npx pagefind --site public --output-subdir pagefind",
+        "partial-build": "hugo --gc",
         "dev": "hugo server",
         "full-dev": "hugo --gc && npx pagefind --site public --serve"
     },

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,0 +1,51 @@
+'use strict';
+
+document.addEventListener('DOMContentLoaded', function() {
+    new PagefindUI({ 
+      element: "#search",
+      showSubResults: true,
+      showImages: false,
+      sort: { date: "desc" }
+    });
+    
+    const searchContainer = document.getElementById('search');
+    const searchToggle = document.getElementById('search-toggle');
+    const searchIcon = searchToggle.querySelector('.search-icon');
+    const closeIcon = searchToggle.querySelector('.close-icon');
+    
+    searchContainer.style.display = 'none';
+
+    function closeSearch() {
+      searchContainer.classList.add('fade-out');
+      setTimeout(() => {
+        searchContainer.style.display = 'none';
+        searchContainer.classList.remove('fade-out');
+        searchIcon.style.display = 'inline';
+        closeIcon.style.display = 'none';
+      }, 125); 
+    }
+    
+    searchToggle.addEventListener('click', function(e) {
+      e.preventDefault();
+      if (searchContainer.style.display === 'none') {
+        searchContainer.style.display = 'block';
+        searchContainer.querySelector('input').focus();
+        searchIcon.style.display = 'none';
+        closeIcon.style.display = 'inline';
+      } else {
+        closeSearch();
+      }
+    });
+    
+    document.addEventListener('click', function(e) {
+      if (!searchContainer.contains(e.target) && !searchToggle.contains(e.target)) {
+        closeSearch();
+      }
+    });
+    
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape' && searchContainer.style.display === 'block') {
+        closeSearch();
+      }
+    });
+});

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', function() {
       showImages: false,
       sort: { date: "desc" }, // sort by date descending
       translations: {
-        placeholder: "Search anything from NUSHackers...",
+        placeholder: "Search anything from NUS Hackers...",
         zero_results: "Couldn't find [SEARCH_TERM]. Try searching for something else.",
     }
       

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', function() {
       element: "#search",
       showSubResults: true,
       showImages: false,
-      sort: { date: "desc" }
+      sort: { date: "desc" } // sort by date descending
     });
     
     const searchContainer = document.getElementById('search');
@@ -22,9 +22,10 @@ document.addEventListener('DOMContentLoaded', function() {
         searchContainer.classList.remove('fade-out');
         searchIcon.style.display = 'inline';
         closeIcon.style.display = 'none';
-      }, 125); 
+      }, 125); // 125ms to prevent flicker behaviour
     }
     
+    // toggle from search icon
     searchToggle.addEventListener('click', function(e) {
       e.preventDefault();
       if (searchContainer.style.display === 'none') {
@@ -38,11 +39,14 @@ document.addEventListener('DOMContentLoaded', function() {
     });
     
     document.addEventListener('click', function(e) {
-      if (!searchContainer.contains(e.target) && !searchToggle.contains(e.target) && window.innerWidth >= 768) {
-      closeSearch();
+      // Check if the click is outside the search container when not on mobile, and click was due to 'more results' button
+      if (!searchContainer.contains(e.target) && !searchToggle.contains(e.target) && 
+      window.innerWidth >= 768 && !e.target.classList.contains('pagefind-ui__button')) {
+        closeSearch();
       }
     });
     
+    // close search on escape key
     document.addEventListener('keydown', function(e) {
       if (e.key === 'Escape' && searchContainer.style.display === 'block') {
         closeSearch();

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -54,6 +54,10 @@ document.addEventListener('DOMContentLoaded', function() {
     if (mobileExitButton) {
         mobileExitButton.addEventListener('click', function(e) {
             e.preventDefault();
+
+            // force pagefind to clear results
+            document.getElementsByClassName('pagefind-ui__search-clear')[0].click();
+
             closeSearch();
         });
     }

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -38,8 +38,8 @@ document.addEventListener('DOMContentLoaded', function() {
     });
     
     document.addEventListener('click', function(e) {
-      if (!searchContainer.contains(e.target) && !searchToggle.contains(e.target)) {
-        closeSearch();
+      if (!searchContainer.contains(e.target) && !searchToggle.contains(e.target) && window.innerWidth >= 768) {
+      closeSearch();
       }
     });
     
@@ -48,4 +48,13 @@ document.addEventListener('DOMContentLoaded', function() {
         closeSearch();
       }
     });
+
+    const mobileExitButton = searchContainer.querySelector('.mobile-search-exit');
+    
+    if (mobileExitButton) {
+        mobileExitButton.addEventListener('click', function(e) {
+            e.preventDefault();
+            closeSearch();
+        });
+    }
 });

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -5,7 +5,12 @@ document.addEventListener('DOMContentLoaded', function() {
       element: "#search",
       showSubResults: true,
       showImages: false,
-      sort: { date: "desc" } // sort by date descending
+      sort: { date: "desc" }, // sort by date descending
+      translations: {
+        placeholder: "Search anything from NUSHackers...",
+        zero_results: "Couldn't find [SEARCH_TERM]. Try searching for something else.",
+    }
+      
     });
     
     const searchContainer = document.getElementById('search');

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,31 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@pagefind/darwin-arm64@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@pagefind/darwin-arm64/-/darwin-arm64-1.3.0.tgz#f1e63d031ba710c98b0b83db85df9251a255f543"
+  integrity sha512-365BEGl6ChOsauRjyVpBjXybflXAOvoMROw3TucAROHIcdBvXk9/2AmEvGFU0r75+vdQI4LJdJdpH4Y6Yqaj4A==
+
+"@pagefind/darwin-x64@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@pagefind/darwin-x64/-/darwin-x64-1.3.0.tgz#10aa3c5988daa464c5c0db5c5aa4bf72e9bbfba1"
+  integrity sha512-zlGHA23uuXmS8z3XxEGmbHpWDxXfPZ47QS06tGUq0HDcZjXjXHeLG+cboOy828QIV5FXsm9MjfkP5e4ZNbOkow==
+
+"@pagefind/linux-arm64@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@pagefind/linux-arm64/-/linux-arm64-1.3.0.tgz#cceb0391901736427738ee1232ff326a985eda8a"
+  integrity sha512-8lsxNAiBRUk72JvetSBXs4WRpYrQrVJXjlRRnOL6UCdBN9Nlsz0t7hWstRk36+JqHpGWOKYiuHLzGYqYAqoOnQ==
+
+"@pagefind/linux-x64@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@pagefind/linux-x64/-/linux-x64-1.3.0.tgz#06ec4c2907780a75d2fb65a22203c5a48abe7a82"
+  integrity sha512-hAvqdPJv7A20Ucb6FQGE6jhjqy+vZ6pf+s2tFMNtMBG+fzcdc91uTw7aP/1Vo5plD0dAOHwdxfkyw0ugal4kcQ==
+
+"@pagefind/windows-x64@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@pagefind/windows-x64/-/windows-x64-1.3.0.tgz#ce3394e5143aaca4850a33473a07628971773655"
+  integrity sha512-BR1bIRWOMqkf8IoU576YDhij1Wd/Zf2kX/kCI0b2qzCKC8wcc2GQJaaRMCpzvCCrmliO4vtJ6RITp/AnoYUUmQ==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -409,6 +434,17 @@ once@^1.3.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+pagefind@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/pagefind/-/pagefind-1.3.0.tgz#467560447dcc7bbe590f1b888cc8bc733bb377fa"
+  integrity sha512-8KPLGT5g9s+olKMRTU9LFekLizkVIu9tes90O1/aigJ0T5LmyPqTzGJrETnSw3meSYg58YH7JTzhTTW/3z6VAw==
+  optionalDependencies:
+    "@pagefind/darwin-arm64" "1.3.0"
+    "@pagefind/darwin-x64" "1.3.0"
+    "@pagefind/linux-arm64" "1.3.0"
+    "@pagefind/linux-x64" "1.3.0"
+    "@pagefind/windows-x64" "1.3.0"
 
 path-is-absolute@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Implement search functionality into site.

**Changes to package.json**
Note that to **deploy locally**, run `yarn full-dev`. This is because pagefind js and css are generated in the /public/pagefind directory, which will not be served when running `yarn dev`. However, when running full-dev, live-reload is unavailable.

Yarn `build` command is now `hugo --gc && npx pagefind --site public --output-subdir pagefind`, which runs hugo build before using pagefind to index relevant files for search functionality. 

I also created a yarn `partial-build` command, `hugo --gc`, which only builds hugo without running pagefind,

**Implementation details**
Search bar and results are overlayed above pages, using the partial `search.html`. search is invoked by clicking `navbar.html` icon and `search.js handles toggling`

Search is ordered by date. 
- `section.html`: Generic pages such as main, /about, and /community are given date of `2099-01-01` to appear on top
- `single.html`: title is determined by post title `data-pagefind-meta`, and dates `data-pagefind-sort` are by date of post

Only content within the tag `data-pagefind-body` are indexed by pagefind and will be shown in results.