### PR TITLE
feat: Maintain FH Category Page + chore: FH282 (Vercel) 

### DIFF
--- a/content/post/2011-08-28-friday-hacks-1.md
+++ b/content/post/2011-08-28-friday-hacks-1.md
@@ -1,6 +1,7 @@
 ---
 author: ejames
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2011-08-28-friday-hacks-1.md
+++ b/content/post/2011-08-28-friday-hacks-1.md
@@ -3,7 +3,6 @@ author: ejames
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2011-08-28T00:00:00.000Z
 title: 'Friday Hacks #1'

--- a/content/post/2011-09-08-this-weeks-friday-hacks.md
+++ b/content/post/2011-09-08-this-weeks-friday-hacks.md
@@ -1,6 +1,7 @@
 ---
 author: ejames
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2011-09-08-this-weeks-friday-hacks.md
+++ b/content/post/2011-09-08-this-weeks-friday-hacks.md
@@ -3,10 +3,9 @@ author: ejames
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2011-09-08T00:00:00.000Z
-title: 'Friday Hacks #2'
+title: "Friday Hacks #2"
 url: /2011/09/this-weeks-friday-hacks/
 aliases:
   - /2011/09/08/this-weeks-friday-hacks/
@@ -15,7 +14,7 @@ aliases:
 <strong>Update! Venue is now changed to Seminar Room 9, on the second floor of the Education Resource Centre, UTown
 </strong>
 
-Will be held at the Collaborative Commons at UTown. That's on the first floor of the Education Resource Center (above Starbucks), next to the PC Commons. We'll be having James Yong over to give an informal, one hour talk about PCB etching, and have gotten the word out to a  couple of members to come and listen in.
+Will be held at the Collaborative Commons at UTown. That's on the first floor of the Education Resource Center (above Starbucks), next to the PC Commons. We'll be having James Yong over to give an informal, one hour talk about PCB etching, and have gotten the word out to a couple of members to come and listen in.
 
 The rest of us may choose to listen in, or otherwise would be perfectly alright with working on your own stuff, with earphones. We've also set up a <a href="//nushackers.pbworks.com/w/page/45116359/Friday%20Hacks%20Ideas%20and%20Instructions">wiki to get new beginners started</a> on Friday Hacks - be it for their homework, new projects, or other stuff.
 

--- a/content/post/2011-09-10-friday-hacks-2.md
+++ b/content/post/2011-09-10-friday-hacks-2.md
@@ -1,6 +1,7 @@
 ---
 author: ejames
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2011-09-10-friday-hacks-2.md
+++ b/content/post/2011-09-10-friday-hacks-2.md
@@ -3,10 +3,9 @@ author: ejames
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2011-09-10T00:00:00.000Z
-title: 'Friday Hacks #2 Recap'
+title: "Friday Hacks #2 Recap"
 url: /2011/09/friday-hacks-2
 ---
 
@@ -35,6 +34,7 @@ The slides are available for download <a href="/downloads/pcb.pdf">here</a>, and
 </ul>
 
 Anyone who's interested in buying the above may contact James at <script type="text/javascript" language="javascript">
+
 <!--
 { coded = "7RXFi0yQcXF@FyH0Q.fRy"
   key = "gKzQGH7xn9ouwE6vckYUMFBDP5mLhXZRpVb2Tfi134SAlNaytOJrI8Cjseq0Wd"
@@ -53,7 +53,9 @@ Anyone who's interested in buying the above may contact James at <script type="t
 document.write("<a href='mailto:"+link+"'>yongkimleng@gmail.com</a>")
 }
 //-->
+
 </script><noscript>Sorry, you need Javascript turned on to see this email.</noscript> and Tay Wenbin at <script type="text/javascript" language="javascript">
+
 <!--
 { coded = "HYpEbP3wP@0FYwo.BjF"
   key = "KEROPr50CvbyHVad6LFslhGDMiAcW3p29Yuz1Txo4ZQ8wqBnIXgNfektJ7jUSm"
@@ -72,6 +74,7 @@ document.write("<a href='mailto:"+link+"'>yongkimleng@gmail.com</a>")
 document.write("<a href='mailto:"+link+"'>taywenbin@gmail.com</a>")
 }
 //-->
+
 </script><noscript>Sorry, you need Javascript turned on to see this email.</noscript>
 
 (Note: the above two email addresses are obfuscated by Javascript, so you'll need to turn your JS on to see it).

--- a/content/post/2011-09-15-friday-hacks-3.md
+++ b/content/post/2011-09-15-friday-hacks-3.md
@@ -1,6 +1,7 @@
 ---
 author: ejames
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2011-09-15-friday-hacks-3.md
+++ b/content/post/2011-09-15-friday-hacks-3.md
@@ -3,10 +3,9 @@ author: ejames
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2011-09-15T00:00:00.000Z
-title: 'Friday Hacks #3'
+title: "Friday Hacks #3"
 url: /2011/09/friday-hacks-3
 ---
 

--- a/content/post/2011-09-29-friday-hacks-4.md
+++ b/content/post/2011-09-29-friday-hacks-4.md
@@ -1,6 +1,7 @@
 ---
 author: ejames
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2011-09-29-friday-hacks-4.md
+++ b/content/post/2011-09-29-friday-hacks-4.md
@@ -3,10 +3,9 @@ author: ejames
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2011-09-29T00:00:00.000Z
-title: 'Friday Hacks #4'
+title: "Friday Hacks #4"
 url: /2011/09/friday-hacks-4
 ---
 

--- a/content/post/2011-10-05-friday-hacks-4.md
+++ b/content/post/2011-10-05-friday-hacks-4.md
@@ -1,6 +1,7 @@
 ---
 author: ejames
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2011-10-05-friday-hacks-4.md
+++ b/content/post/2011-10-05-friday-hacks-4.md
@@ -3,10 +3,9 @@ author: ejames
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2011-10-05T00:00:00.000Z
-title: 'Friday Hacks #4 Recap'
+title: "Friday Hacks #4 Recap"
 url: /2011/10/friday-hacks-4
 ---
 

--- a/content/post/2011-10-05-friday-hacks-5.md
+++ b/content/post/2011-10-05-friday-hacks-5.md
@@ -1,6 +1,7 @@
 ---
 author: ejames
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2011-10-05-friday-hacks-5.md
+++ b/content/post/2011-10-05-friday-hacks-5.md
@@ -3,10 +3,9 @@ author: ejames
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2011-10-05T00:00:00.000Z
-title: 'Friday Hacks #5'
+title: "Friday Hacks #5"
 url: /2011/10/friday-hacks-5
 ---
 

--- a/content/post/2011-10-18-friday-hacks-6.md
+++ b/content/post/2011-10-18-friday-hacks-6.md
@@ -1,6 +1,7 @@
 ---
 author: ejames
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2011-10-18-friday-hacks-6.md
+++ b/content/post/2011-10-18-friday-hacks-6.md
@@ -3,14 +3,14 @@ author: ejames
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2011-10-18T00:00:00.000Z
-title: 'Friday Hacks #6'
+title: "Friday Hacks #6"
 url: /2011/10/friday-hacks-6
 ---
 
 For this week's Friday Hacks, Steven Goh, a 4th year CompSci student will be coming down to share with us "Rapid Web Development the right (Pythonic) way"
+
 <div>(I realize NUS Hackers has been rather Python-biased lately, so in the future, if any of you know other languages (Ruby, Haskell, etc) and want to come share your knowledge with us, by all means just email me :)</div>
 <div></div>
 <blockquote>

--- a/content/post/2011-10-28-friday-hacks-7.md
+++ b/content/post/2011-10-28-friday-hacks-7.md
@@ -3,10 +3,9 @@ author: rctay
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2011-10-28T00:00:00.000Z
-title: 'Friday Hacks #7'
+title: "Friday Hacks #7"
 url: /2011/10/friday-hacks-7
 ---
 

--- a/content/post/2011-10-28-friday-hacks-7.md
+++ b/content/post/2011-10-28-friday-hacks-7.md
@@ -1,6 +1,7 @@
 ---
 author: rctay
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2011-11-03-friday-hacks-8.md
+++ b/content/post/2011-11-03-friday-hacks-8.md
@@ -1,6 +1,7 @@
 ---
 author: ejames
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2011-11-03-friday-hacks-8.md
+++ b/content/post/2011-11-03-friday-hacks-8.md
@@ -3,10 +3,9 @@ author: ejames
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2011-11-03T00:00:00.000Z
-title: 'Friday Hacks #8'
+title: "Friday Hacks #8"
 url: /2011/11/friday-hacks-8
 ---
 

--- a/content/post/2012-02-09-friday-hacks-17.md
+++ b/content/post/2012-02-09-friday-hacks-17.md
@@ -1,6 +1,7 @@
 ---
 author: ejames
 categories:
+  - Friday Hacks
   - Meetings
 comments: true
 date: 2012-02-09T00:00:00.000Z

--- a/content/post/2012-02-27-friday-hacks-18.md
+++ b/content/post/2012-02-27-friday-hacks-18.md
@@ -1,6 +1,7 @@
 ---
 author: admin
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2012-02-27-friday-hacks-18.md
+++ b/content/post/2012-02-27-friday-hacks-18.md
@@ -3,7 +3,6 @@ author: admin
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2012-02-27T00:00:00.000Z
 title: Friday Hacks Talk 2nd Mar - Building responsive frontends with Backbone.js
@@ -11,6 +10,7 @@ url: /2012/02/friday-hacks-18
 ---
 
 {{< imglink src="/img/2012/02/417599_304279572963816_164904410234667_838981_1516059813_n.jpeg" alt="" >}}
+
 <div>We're back from the Semester Break with 2 talks this Friday Hacks :)</div>
 <div><span>
 <strong>- Location</strong><strong>:</strong> Seminar Room 2, UTown ERC Level 2</span>

--- a/content/post/2012-03-05-friday-hacks-19.md
+++ b/content/post/2012-03-05-friday-hacks-19.md
@@ -1,6 +1,7 @@
 ---
 author: admin
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2012-03-05-friday-hacks-19.md
+++ b/content/post/2012-03-05-friday-hacks-19.md
@@ -3,7 +3,6 @@ author: admin
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2012-03-05T00:00:00.000Z
 title: Friday Hacks Talk 9th Mar - FREE Nokia Lumia 710 Giveaway + 2 Talks
@@ -13,6 +12,7 @@ url: /2012/03/friday-hacks-19
 <strong>"A Technical Introduction to the Windows Phone Platform"</strong> by Mani Krishnamurthy, Nokia EDX Technical Manager
 
 <strong></strong><strong>"Sync, Sink, Sync"</strong> by Mohit Singh Kanwal, NUS Student
+
 <div>
 <div><img src="/img/2012/03/2012-03-02_211700.png" alt="Inline image 1" /></div>
 </div>

--- a/content/post/2012-03-14-friday-hacks-20.md
+++ b/content/post/2012-03-14-friday-hacks-20.md
@@ -1,6 +1,7 @@
 ---
 author: admin
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2012-03-14-friday-hacks-20.md
+++ b/content/post/2012-03-14-friday-hacks-20.md
@@ -3,7 +3,6 @@ author: admin
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2012-03-14T00:00:00.000Z
 title: Friday Hacks Talk 16th Mar – The Mathematics of Luxury
@@ -13,6 +12,7 @@ url: /2012/03/friday-hacks-20
 <span><strong>Talk #1 - "</strong><strong>The Mathematics of Luxury" (by Dr Shaun Martin, </strong></span><strong>Applied Cognitive Science CEO)</strong>
 
 &nbsp;
+
 <div>
 <div>
 <div>

--- a/content/post/2012-03-21-friday-hacks-21.md
+++ b/content/post/2012-03-21-friday-hacks-21.md
@@ -1,6 +1,7 @@
 ---
 author: admin
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2012-03-21-friday-hacks-21.md
+++ b/content/post/2012-03-21-friday-hacks-21.md
@@ -3,7 +3,6 @@ author: admin
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2012-03-21T00:00:00.000Z
 title: Friday Hacks Talk 23rd Mar – Agile Dev + GSoC Information Session

--- a/content/post/2012-03-26-friday-hacks-22.md
+++ b/content/post/2012-03-26-friday-hacks-22.md
@@ -1,6 +1,7 @@
 ---
 author: admin
 categories:
+  - Friday Hacks
   - Events
   - Friday Hacks
 comments: true

--- a/content/post/2012-03-26-friday-hacks-22.md
+++ b/content/post/2012-03-26-friday-hacks-22.md
@@ -3,7 +3,6 @@ author: admin
 categories:
   - Friday Hacks
   - Events
-  - Friday Hacks
 comments: true
 date: 2012-03-26T00:00:00.000Z
 title: Friday Hacks Talk 30th Mar - Philosophy of Unix
@@ -12,6 +11,7 @@ url: /2012/03/friday-hacks-22
 
 <span style="font-family: arial,helvetica,sans-serif;">{{< imglink src="/img/2012/03/unix_plate.jpg" alt="" >}}
 </span>
+
 <div></div>
 <div>
 <div><p><span style="font-family: arial,helvetica,sans-serif;">In conjunction with Linux Week, we have Professor Michael Brown with us!</span></div>

--- a/content/post/2012-04-06-friday-hacks-23.md
+++ b/content/post/2012-04-06-friday-hacks-23.md
@@ -1,6 +1,7 @@
 ---
 author: ejames
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2012-04-06T00:00:00.000Z

--- a/content/post/2012-04-06-friday-hacks-23.md
+++ b/content/post/2012-04-06-friday-hacks-23.md
@@ -2,7 +2,7 @@
 author: ejames
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2012-04-06T00:00:00.000Z
 title: Friday Hacks Talk 6th Apr -Big Data & Intro to Erlang

--- a/content/post/2012-10-16-friday-hacks-33.md
+++ b/content/post/2012-10-16-friday-hacks-33.md
@@ -1,6 +1,7 @@
 ---
 author: ejames
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2012-10-16T00:00:00.000Z

--- a/content/post/2012-10-16-friday-hacks-33.md
+++ b/content/post/2012-10-16-friday-hacks-33.md
@@ -2,10 +2,10 @@
 author: ejames
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2012-10-16T00:00:00.000Z
-title: 'Friday Hacks #33, Oct 19'
+title: "Friday Hacks #33, Oct 19"
 url: /2012/10/friday-hacks-33
 ---
 
@@ -20,7 +20,7 @@ Talks start promptly at 7pm. You are welcome to stay and mingle (or hack!) after
 <h3>Talk 1: Sound and Interaction in the browser using the WebAudio API</h3>
 
 <strong>Preparation:</strong>
-If you want to "code along" to make some noise of your own, bring your computer with the Chrome *Canary* Browser installed.
+If you want to "code along" to make some noise of your own, bring your computer with the Chrome _Canary_ Browser installed.
 
 <strong>Talk Description:</strong>
 The formative WebAudio API will make powerful real-time and interactive sound synthesis standard fare for browsers. Coupled with new networking technologies, and APIs for accessing device capabilities, this ain't your grandmothers browser any more. The talk will present some recent explorations with WebAudio, discuss some of the open issues with the developing standard, and show you how you can add interactive sound to your web pages.

--- a/content/post/2012-11-12-friday-hacks-36.md
+++ b/content/post/2012-11-12-friday-hacks-36.md
@@ -1,6 +1,7 @@
 ---
 author: ejames
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2012-11-12T00:00:00.000Z

--- a/content/post/2012-11-12-friday-hacks-36.md
+++ b/content/post/2012-11-12-friday-hacks-36.md
@@ -2,16 +2,17 @@
 author: ejames
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2012-11-12T00:00:00.000Z
-title: 'Friday Hacks #36, Nov 16: On Impact - An Introduction to Palantir'
+title: "Friday Hacks #36, Nov 16: On Impact - An Introduction to Palantir"
 url: /2012/11/friday-hacks-36
 ---
 
 This Friday, Palantir will be coming to NUS to give a recruiting talk. Food will be served after the talk, and a <strong>Nexus 7 giveaway </strong>will be held for one lucky registrant at the end of the event.
 
 To sign up for this talk, and to apply for job opportunities at Palantir, please register at this link: <a href="//bit.ly/palantir-sg-2012" target="_blank">//bit.ly/palantir-<wbr>sg-2012</wbr></a>
+
 <p style="text-align: center;">{{< imglink src="/img/2012/11/palantir-2012-NUS.png" alt="" >}}</p>
 
 <div>

--- a/content/post/2013-01-16-friday-hacks-37.md
+++ b/content/post/2013-01-16-friday-hacks-37.md
@@ -1,6 +1,7 @@
 ---
 author: omer
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-01-16T00:00:00.000Z

--- a/content/post/2013-01-16-friday-hacks-37.md
+++ b/content/post/2013-01-16-friday-hacks-37.md
@@ -2,10 +2,10 @@
 author: omer
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-01-16T00:00:00.000Z
-title: 'Friday Hacks #37, Jan 18'
+title: "Friday Hacks #37, Jan 18"
 url: /2013/01/friday-hacks-37
 ---
 

--- a/content/post/2013-02-06-friday-hacks-40.md
+++ b/content/post/2013-02-06-friday-hacks-40.md
@@ -2,14 +2,15 @@
 author: benedict
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-02-06T00:00:00.000Z
-title: 'Friday Hacks #40, Feb 8'
+title: "Friday Hacks #40, Feb 8"
 url: /2013/02/friday-hacks-40
 ---
 
 This week we have Michael Rawlinson, who will share with us the job prospects in the UK. Those interested in the Interactive Entertainment Industry should definitely come for the talk!
+
 <blockquote><strong>Date/Time:</strong> Friday, February 8 at 6:30pm
 <strong>Venue:</strong> SR2, Education Resource Centre, University Town. Map: <a href="//goo.gl/maps/2Zy3M">//goo.gl/maps/2Zy3M</a>
 <strong>Sign up here:</strong> <a href="//bit.ly/fridayhacks2013">//bit.ly/fridayhacks2013</a>
@@ -29,6 +30,7 @@ Michael Rawlinson was CEO of UKIE (WWW.UKIE.ORG.UK ) the trade association for t
 During his tenure he transformed the organisation from being solely focused on representing publishers when it was called ELSPA to broadening it remit to encompass the whole of the interactive entertainment sector.
 
 Other highlights include:
+
 <ul>
 <li>
 the creation of the first Pan-European content classification system – PEGI (www.pegi.info ),

--- a/content/post/2013-02-06-friday-hacks-40.md
+++ b/content/post/2013-02-06-friday-hacks-40.md
@@ -1,6 +1,7 @@
 ---
 author: benedict
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-02-06T00:00:00.000Z

--- a/content/post/2013-02-14-friday-hacks-41.md
+++ b/content/post/2013-02-14-friday-hacks-41.md
@@ -2,10 +2,10 @@
 author: benedict
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-02-14T00:00:00.000Z
-title: 'Friday Hacks #41, Feb 15'
+title: "Friday Hacks #41, Feb 15"
 url: /2013/02/friday-hacks-41
 ---
 

--- a/content/post/2013-02-14-friday-hacks-41.md
+++ b/content/post/2013-02-14-friday-hacks-41.md
@@ -1,6 +1,7 @@
 ---
 author: benedict
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-02-14T00:00:00.000Z

--- a/content/post/2013-02-21-friday-hacks-42.md
+++ b/content/post/2013-02-21-friday-hacks-42.md
@@ -1,6 +1,7 @@
 ---
 author: benedict
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-02-21T00:00:00.000Z

--- a/content/post/2013-02-21-friday-hacks-42.md
+++ b/content/post/2013-02-21-friday-hacks-42.md
@@ -2,10 +2,10 @@
 author: benedict
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-02-21T00:00:00.000Z
-title: 'Friday Hacks #42, Feb 22'
+title: "Friday Hacks #42, Feb 22"
 url: /2013/02/friday-hacks-42
 ---
 

--- a/content/post/2013-03-08-friday-hacks-43.md
+++ b/content/post/2013-03-08-friday-hacks-43.md
@@ -1,6 +1,7 @@
 ---
 author: michael
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-03-08T00:00:00.000Z

--- a/content/post/2013-03-08-friday-hacks-43.md
+++ b/content/post/2013-03-08-friday-hacks-43.md
@@ -2,10 +2,10 @@
 author: michael
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-03-08T00:00:00.000Z
-title: 'Friday Hacks #43, Mar 8'
+title: "Friday Hacks #43, Mar 8"
 url: /2013/03/friday-hacks-43
 ---
 

--- a/content/post/2013-03-14-friday-hacks-44.md
+++ b/content/post/2013-03-14-friday-hacks-44.md
@@ -1,6 +1,7 @@
 ---
 author: michael
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-03-14T00:00:00.000Z

--- a/content/post/2013-03-14-friday-hacks-44.md
+++ b/content/post/2013-03-14-friday-hacks-44.md
@@ -2,10 +2,10 @@
 author: michael
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-03-14T00:00:00.000Z
-title: 'Friday Hacks #44, Mar 15'
+title: "Friday Hacks #44, Mar 15"
 url: /2013/03/friday-hacks-44
 ---
 
@@ -24,7 +24,7 @@ As always, there'll be drinks, pizza and a fun crowd to mingle with.
 
 We look forward to seeing you there!
 
-*Tell us what you think about this alternative format of Friday Hacks :)
+\*Tell us what you think about this alternative format of Friday Hacks :)
 
 ==============================
 

--- a/content/post/2013-03-20-friday-hacks-45.md
+++ b/content/post/2013-03-20-friday-hacks-45.md
@@ -1,6 +1,7 @@
 ---
 author: benedict
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-03-20T00:00:00.000Z

--- a/content/post/2013-03-20-friday-hacks-45.md
+++ b/content/post/2013-03-20-friday-hacks-45.md
@@ -2,14 +2,15 @@
 author: benedict
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-03-20T00:00:00.000Z
-title: 'Friday Hacks #45, Mar 22'
+title: "Friday Hacks #45, Mar 22"
 url: /2013/03/friday-hacks-45
 ---
 
 This week we have Dr Michael Brown and Melvin Zhang. These talks are suited for everyone! So come and listen to them!
+
 <blockquote><strong>Date/Time:</strong> Friday, March 22 at 6:30pm
 <strong>Venue:</strong> SR2, Education Resource Centre, University Town. Map: <a href="//goo.gl/maps/2Zy3M">//goo.gl/maps/2Zy3M</a>
 <strong>Sign up here:</strong> <a href="//bit.ly/fridayhacks2013">//bit.ly/fridayhacks2013</a>
@@ -19,7 +20,8 @@ This week we have Dr Michael Brown and Melvin Zhang. These talks are suited for 
 While Unix is best known as an operating system, the founding fathers of Unix developed it around an entire philosophy on how software should be developed. In this talk, I will discuss the history leading up to the development of Unix as well as some of the underlying principles and practices that make up the Unix Philosophy.
 
 <strong>Speaker Profile:</strong>
-Dr. Michael S. Brown is currently an associate professor and assistant dean (external relations) in the School of Computing at NUS.  Dr. Brown’s research interests include computer vision, image processing and computer graphics.
+Dr. Michael S. Brown is currently an associate professor and assistant dean (external relations) in the School of Computing at NUS. Dr. Brown’s research interests include computer vision, image processing and computer graphics.
+
 <h3>Talk 2: Automating your command line workflow with Make (NUS Alum/Programmer@Hoiio)</h3>
 <strong>Talk Description:</strong>
 Make is often used to compile a program from its source files. However, Make is not specific to compilation, it just helps you to invoke the compiler. Make keeps track of dependencies between files and the commands for generating the files. Instead of specifying the command you want to perform, you tell Make to produce a particular file and it figures out and invokes the commands to do so.

--- a/content/post/2013-04-04-friday-hacks-46.md
+++ b/content/post/2013-04-04-friday-hacks-46.md
@@ -2,10 +2,10 @@
 author: benedict
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-04-04T00:00:00.000Z
-title: 'Friday Hacks #46, Apr 5'
+title: "Friday Hacks #46, Apr 5"
 url: /2013/04/friday-hacks-46
 ---
 

--- a/content/post/2013-04-04-friday-hacks-46.md
+++ b/content/post/2013-04-04-friday-hacks-46.md
@@ -1,6 +1,7 @@
 ---
 author: benedict
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-04-04T00:00:00.000Z

--- a/content/post/2013-04-12-friday-hacks-47.md
+++ b/content/post/2013-04-12-friday-hacks-47.md
@@ -1,6 +1,7 @@
 ---
 author: benedict
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-04-12T00:00:00.000Z

--- a/content/post/2013-04-12-friday-hacks-47.md
+++ b/content/post/2013-04-12-friday-hacks-47.md
@@ -2,10 +2,10 @@
 author: benedict
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-04-12T00:00:00.000Z
-title: 'Friday Hacks #47, Apr 12'
+title: "Friday Hacks #47, Apr 12"
 url: /2013/04/friday-hacks-47
 ---
 

--- a/content/post/2013-04-17-friday-hacks-48.md
+++ b/content/post/2013-04-17-friday-hacks-48.md
@@ -1,6 +1,7 @@
 ---
 author: benedict
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-04-17T00:00:00.000Z

--- a/content/post/2013-04-17-friday-hacks-48.md
+++ b/content/post/2013-04-17-friday-hacks-48.md
@@ -2,10 +2,10 @@
 author: benedict
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-04-17T00:00:00.000Z
-title: 'Friday Hacks #48, Apr 19'
+title: "Friday Hacks #48, Apr 19"
 url: /2013/04/friday-hacks-48
 ---
 

--- a/content/post/2013-10-02-friday-hacks-53.md
+++ b/content/post/2013-10-02-friday-hacks-53.md
@@ -2,14 +2,15 @@
 author: admin
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-10-02T00:00:00.000Z
-title: 'Friday Hacks #53, Oct 4'
+title: "Friday Hacks #53, Oct 4"
 url: /2013/10/friday-hacks-53
 ---
 
 This week we have Cedric Chin and Divyanshu Arora.
+
 <blockquote><strong>Date/Time:</strong> Friday, October 4 at 6:30pm
 <strong>Venue:</strong> SR2, Education Resource Centre, University Town. Map: <a href="//goo.gl/maps/2Zy3M">//goo.gl/maps/2Zy3M</a>
 <strong>Sign up here:</strong> <a href="//bit.ly/fridayhacks2013">//bit.ly/fridayhacks2013</a>

--- a/content/post/2013-10-02-friday-hacks-53.md
+++ b/content/post/2013-10-02-friday-hacks-53.md
@@ -1,6 +1,7 @@
 ---
 author: admin
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-10-02T00:00:00.000Z

--- a/content/post/2013-10-09-friday-hacks-54.md
+++ b/content/post/2013-10-09-friday-hacks-54.md
@@ -2,14 +2,15 @@
 author: admin
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-10-09T00:00:00.000Z
-title: 'Friday Hacks #54, Oct 11'
+title: "Friday Hacks #54, Oct 11"
 url: /2013/10/friday-hacks-54
 ---
 
 This week we have Fazli Sapuan and Fazli Sapuan. Followed by talk(s) which are hopefully A.I. themed (maybe), and then a series of ad-hoc lightning talks by members of the community.
+
 <blockquote><strong>Date/Time:</strong> Friday, October 11 at 6:30pm
 <strong>Venue:</strong> SR2, Education Resource Centre, University Town. Map: <a href="//goo.gl/maps/2Zy3M">//goo.gl/maps/2Zy3M</a>
 <strong>Sign up here:</strong> <a href="//bit.ly/fridayhacks2013">//bit.ly/fridayhacks2013</a>

--- a/content/post/2013-10-09-friday-hacks-54.md
+++ b/content/post/2013-10-09-friday-hacks-54.md
@@ -1,6 +1,7 @@
 ---
 author: admin
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-10-09T00:00:00.000Z

--- a/content/post/2013-10-24-friday-hacks-56.md
+++ b/content/post/2013-10-24-friday-hacks-56.md
@@ -1,6 +1,7 @@
 ---
 author: admin
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-10-24T00:00:00.000Z

--- a/content/post/2013-10-24-friday-hacks-56.md
+++ b/content/post/2013-10-24-friday-hacks-56.md
@@ -2,14 +2,15 @@
 author: admin
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-10-24T00:00:00.000Z
-title: 'Friday Hacks #56, Oct 25'
+title: "Friday Hacks #56, Oct 25"
 url: /2013/10/friday-hacks-56
 ---
 
 This week we have Nick Jachowski and Lin Zhihao.
+
 <blockquote><strong>Date/Time:</strong> Friday, October 25 at 6:30pm
 <strong>Venue:</strong> SR2, Education Resource Centre, University Town. Map: <a href="//goo.gl/maps/2Zy3M">//goo.gl/maps/2Zy3M</a>
 <strong>Sign up here:</strong> <a href="//bit.ly/fridayhacks2013">//bit.ly/fridayhacks2013</a>

--- a/content/post/2013-10-30-friday-hacks-57.md
+++ b/content/post/2013-10-30-friday-hacks-57.md
@@ -1,6 +1,7 @@
 ---
 author: admin
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-10-30T00:00:00.000Z

--- a/content/post/2013-10-30-friday-hacks-57.md
+++ b/content/post/2013-10-30-friday-hacks-57.md
@@ -2,14 +2,15 @@
 author: admin
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-10-30T00:00:00.000Z
-title: 'Friday Hacks #57, Nov 1'
+title: "Friday Hacks #57, Nov 1"
 url: /2013/10/friday-hacks-57
 ---
 
 This week we have Giovanni Casinelli.
+
 <blockquote><strong>Date/Time:</strong> Friday, November 1 at 6:30pm
 <strong>Venue:</strong> SR2, Education Resource Centre, University Town. Map: <a href="//goo.gl/maps/2Zy3M">//goo.gl/maps/2Zy3M</a>
 <strong>Sign up here:</strong> <a href="//bit.ly/fridayhacks2013">//bit.ly/fridayhacks2013</a>

--- a/content/post/2013-11-07-friday-hacks-58.md
+++ b/content/post/2013-11-07-friday-hacks-58.md
@@ -2,14 +2,15 @@
 author: admin
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-11-07T00:00:00.000Z
-title: 'Friday Hacks #58, Nov 8'
+title: "Friday Hacks #58, Nov 8"
 url: /2013/11/friday-hacks-58
 ---
 
 This week we have Lee Chuk Munn.
+
 <blockquote><strong>Date/Time:</strong> Friday, November 8 at 6:30pm
 <strong>Venue:</strong> SR2, Education Resource Centre, University Town. Map: <a href="//goo.gl/maps/2Zy3M">//goo.gl/maps/2Zy3M</a>
 <strong>Sign up here:</strong> <a href="//bit.ly/fridayhacks2013">//bit.ly/fridayhacks2013</a>

--- a/content/post/2013-11-07-friday-hacks-58.md
+++ b/content/post/2013-11-07-friday-hacks-58.md
@@ -1,6 +1,7 @@
 ---
 author: admin
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-11-07T00:00:00.000Z

--- a/content/post/2013-11-15-friday-hacks-59.md
+++ b/content/post/2013-11-15-friday-hacks-59.md
@@ -2,10 +2,10 @@
 author: admin
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2013-11-15T00:00:00.000Z
-title: 'Friday Hacks #59, Nov 15'
+title: "Friday Hacks #59, Nov 15"
 url: /2013/11/friday-hacks-59
 ---
 

--- a/content/post/2013-11-15-friday-hacks-59.md
+++ b/content/post/2013-11-15-friday-hacks-59.md
@@ -1,6 +1,7 @@
 ---
 author: admin
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2013-11-15T00:00:00.000Z

--- a/content/post/2014-02-04-friday-hacks-62.md
+++ b/content/post/2014-02-04-friday-hacks-62.md
@@ -2,22 +2,25 @@
 author: vishnu
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2014-02-04T00:00:00.000Z
-title: 'Friday Hacks #62, Feb 7'
+title: "Friday Hacks #62, Feb 7"
 url: /2014/02/friday-hacks-62
 ---
 
 This week, we have a talk by Alex Teo from D'Crypt. Do note the change in venue, it's back at UTown again! See you there
+
 <blockquote><strong>Date/Time:</strong> Friday, February 7th at 6:30pm
 <strong>Venue:</strong> SR2, Education Resource Centre, University Town; <strong>Map</strong>: <a href="//goo.gl/maps/2Zy3M">//goo.gl/maps/2Zy3M</a>
 
 <strong style="line-height: 1.5em;">Free pizza is served before the talks.</strong></blockquote>
+
 <h3>Talk: Bitcoin Mining at D'Crypt</h3>
 <div>
 
 <strong>Talk Description:</strong>
+
 <div>Bitcoin is a P2P digital crypto-currency that has taken the world by storm. At D'Crypt, we have recently developed a Bitcoin miner that runs on our high performance FPGA-based compute node named Raptor. We would like to take the opportunity to provide a short overview on Bitcoin and to present our work on Bitcoin mining.</div>
 <strong style="line-height: 1.5em;">Speaker Profile:</strong><strong></strong>
 <div>Alex is currently an engineer at D'Crypt Pte Ltd, a local engineering company that works on embedded cryptographic solutions and services. He recently graduated from NUS Faculty of Engineering, majoring in Computer Engineering. Alex designs custom FPGA-based applications that run on our high-performance compute nodes at D'Crypt.</div>

--- a/content/post/2014-02-04-friday-hacks-62.md
+++ b/content/post/2014-02-04-friday-hacks-62.md
@@ -1,6 +1,7 @@
 ---
 author: vishnu
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2014-02-04T00:00:00.000Z

--- a/content/post/2014-02-19-friday-hacks-64.md
+++ b/content/post/2014-02-19-friday-hacks-64.md
@@ -1,6 +1,7 @@
 ---
 author: vishnu
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2014-02-19T00:00:00.000Z

--- a/content/post/2014-02-19-friday-hacks-64.md
+++ b/content/post/2014-02-19-friday-hacks-64.md
@@ -2,23 +2,26 @@
 author: vishnu
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2014-02-19T00:00:00.000Z
-title: 'Friday Hacks #64, Feb 21'
+title: "Friday Hacks #64, Feb 21"
 url: /2014/02/friday-hacks-64
 ---
 
 This Friday, we have a talk by Indra from SimplerCloud. See you!
+
 <blockquote><strong>Date/Time:</strong> Friday, February 21st at 6:30pm
 <strong>Venue:</strong> SR2, Education Resource Centre, University Town; <strong>Map</strong>: <a href="//goo.gl/maps/2Zy3M">//goo.gl/maps/2Zy3M</a><strong>
 </strong>
 
 <strong>Free pizza is served before the talks.</strong></blockquote>
+
 <h3>Talk: DNS Spoofing - The Basics and How to Prevent it</h3>
 <div>
 
 <strong>Talk Description:</strong>
+
 <div>How can you take down a country's Internet and prevent more than 6 million users from surfing web pages for 8 hours without even standing up? Try DNS cache poisoning. In late January 2014, a case of DNS spoofing in China caused all web queries to be routed to a single IP address in the US, suspending two-thirds of all Chinese internet traffic for several hours. The Domain Name System (DNS) is the fundamental addressing system that runs the Internet.  This talk gives a brief overview of how it works, and briefly addresses DNS cache poisoning, also known as DNS spoofing, how such issues occur and can be mitigated. Learning a bit about DNS cache poisoning could go a long way towards preventing major issues.</div>
 <div></div>
 <div><strong>Speaker Profile:</strong></div>

--- a/content/post/2014-03-04-friday-hacks-65.md
+++ b/content/post/2014-03-04-friday-hacks-65.md
@@ -1,6 +1,7 @@
 ---
 author: michael
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2014-03-04T00:00:00.000Z

--- a/content/post/2014-03-04-friday-hacks-65.md
+++ b/content/post/2014-03-04-friday-hacks-65.md
@@ -2,7 +2,6 @@
 author: michael
 categories:
   - Friday Hacks
-  - Uncategorized
 comments: true
 date: 2014-03-04T00:00:00.000Z
 title: 'Friday Hacks #65, March 7'

--- a/content/post/2014-03-12-friday-hacks-66.md
+++ b/content/post/2014-03-12-friday-hacks-66.md
@@ -2,14 +2,15 @@
 author: vishnu
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2014-03-12T00:00:00.000Z
-title: 'Friday Hacks #66, March 14'
+title: "Friday Hacks #66, March 14"
 url: /2014/03/friday-hacks-66
 ---
 
 This friday, we have a talk by Chia Yuan from DSO National Laboratories. See you there!
+
 <blockquote><strong>Date/Time</strong>: Friday, March 14th at 6:30pm
 <strong>Venue</strong>: SR2, Education Resource Centre, University Town
 <strong>Map</strong>: <a href="//goo.gl/maps/2Zy3M">//goo.gl/maps/2Zy3M</a>

--- a/content/post/2014-03-12-friday-hacks-66.md
+++ b/content/post/2014-03-12-friday-hacks-66.md
@@ -1,6 +1,7 @@
 ---
 author: vishnu
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2014-03-12T00:00:00.000Z

--- a/content/post/2014-03-19-friday-hacks-67.md
+++ b/content/post/2014-03-19-friday-hacks-67.md
@@ -1,6 +1,7 @@
 ---
 author: vishnu
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2014-03-19T00:00:00.000Z

--- a/content/post/2014-03-19-friday-hacks-67.md
+++ b/content/post/2014-03-19-friday-hacks-67.md
@@ -2,14 +2,15 @@
 author: vishnu
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2014-03-19T00:00:00.000Z
-title: 'Friday Hacks #67, March 21'
+title: "Friday Hacks #67, March 21"
 url: /2014/03/friday-hacks-67
 ---
 
 This friday, we have a talk by Lee Chun Munn from Institute of Systems Science about what's new in Java 8. See you there!
+
 <blockquote><strong>Date/Time</strong>: Friday, March 21th at 6:30pm
 <strong>Venue</strong>: SR2, Education Resource Centre, University Town
 <strong>Map</strong>: <a href="//goo.gl/maps/2Zy3M">//goo.gl/maps/2Zy3M</a>

--- a/content/post/2014-03-26-friday-hacks-68.md
+++ b/content/post/2014-03-26-friday-hacks-68.md
@@ -1,6 +1,7 @@
 ---
 author: vishnu
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2014-03-26T00:00:00.000Z

--- a/content/post/2014-03-26-friday-hacks-68.md
+++ b/content/post/2014-03-26-friday-hacks-68.md
@@ -2,14 +2,15 @@
 author: vishnu
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2014-03-26T00:00:00.000Z
-title: 'Friday Hacks #68, March 28'
+title: "Friday Hacks #68, March 28"
 url: /2014/03/friday-hacks-68
 ---
 
 This friday, we have a talk by the awesome Beng Eu about he built NUSMods. See you there! (Also, a little birdie tells us that Jeff Moss <em>might</em> be attending FH this week :))
+
 <blockquote><strong>Date/Time</strong>: Friday, March 28th at 6:30pm
 <strong>Venue</strong>: SR2, Education Resource Centre, University Town
 <strong>Map</strong>: <a href="//goo.gl/maps/2Zy3M">//goo.gl/maps/2Zy3M</a>
@@ -19,6 +20,7 @@ This friday, we have a talk by the awesome Beng Eu about he built NUSMods. See y
 <div>
 
 <strong style="line-height: 1.5em;"></strong>
+
 <div>
 <div>Ever wondered how you could go about building an app like NUSMods?</div>
 </div>

--- a/content/post/2014-03-31-friday-hacks-69.md
+++ b/content/post/2014-03-31-friday-hacks-69.md
@@ -1,6 +1,7 @@
 ---
 author: vishnu
 categories:
+  - Friday Hacks
   - Uncategorized
 comments: true
 date: 2014-03-31T00:00:00.000Z

--- a/content/post/2014-03-31-friday-hacks-69.md
+++ b/content/post/2014-03-31-friday-hacks-69.md
@@ -2,14 +2,15 @@
 author: vishnu
 categories:
   - Friday Hacks
-  - Uncategorized
+
 comments: true
 date: 2014-03-31T00:00:00.000Z
-title: 'Friday Hacks #69, April 4'
+title: "Friday Hacks #69, April 4"
 url: /2014/03/friday-hacks-69
 ---
 
 This friday, we have a talk by Melvin from Hoiio about optimal algorithms. See you there!
+
 <blockquote><strong>Date/Time</strong>: Friday, April 4th at 6:30pm
 <strong>Venue</strong>: SR2, Education Resource Centre, University Town
 <strong>Map</strong>: <a href="//goo.gl/maps/2Zy3M">//goo.gl/maps/2Zy3M</a>

--- a/content/post/2014-04-08-friday-hacks-70.md
+++ b/content/post/2014-04-08-friday-hacks-70.md
@@ -3,6 +3,8 @@ author: vishnu
 date: 2014-04-08T00:00:00.000Z
 title: 'Friday Hacks #70, April 11'
 url: /2014/04/friday-hacks-70
+categories:
+  - Friday Hacks
 ---
 
 For the last Friday hacks of the semester, we have 2 talks by engineers from Viki and Paypal! See you there!

--- a/content/post/2014-08-15-friday-hacks-71.md
+++ b/content/post/2014-08-15-friday-hacks-71.md
@@ -3,6 +3,8 @@ author: Joey
 date: 2014-08-15T23:02:38.000Z
 title: 'Friday Hacks #71, August 15'
 url: /2014/08/friday-hacks-71
+categories:
+  - Friday Hacks
 ---
 
 For our first Friday Hack of AY2014/2015, we will have our Welcome Tea followed by an introduction to open source development by NUSMods creators, Beng and Yang Shun. See you there!

--- a/content/post/2014-08-22-friday-hacks-72.md
+++ b/content/post/2014-08-22-friday-hacks-72.md
@@ -3,6 +3,8 @@ author: Joey
 date: 2014-08-22T21:38:45.000Z
 title: 'Friday Hacks #72, August 22'
 url: /2014/08/friday-hacks-72
+categories:
+  - Friday Hacks
 ---
 
 This week's Friday Hacks is security themed! The Research and Analysis Team from the Singapore Infocomm Technology Security Authority will be here to give us two hands-on talks. See you there!

--- a/content/post/2014-08-29-friday-hacks-73.md
+++ b/content/post/2014-08-29-friday-hacks-73.md
@@ -3,6 +3,8 @@ author: Joey
 date: 2014-08-29T20:23:41.000Z
 title: 'Friday Hacks #73, August 29'
 url: /2014/08/friday-hacks-73
+categories:
+  - Friday Hacks
 ---
 
 This week, Shan will be sharing about his work to optimize underwater modems, and how to get started with electronics. We're also giving away a Raspberry Pi to one lucky attendee, see you there!

--- a/content/post/2014-09-05-friday-hacks-74.md
+++ b/content/post/2014-09-05-friday-hacks-74.md
@@ -3,6 +3,8 @@ author: Joey
 date: 2014-09-05T13:08:10.000Z
 title: 'Friday Hacks #74, September 5'
 url: /2014/09/friday-hacks-74
+categories:
+  - Friday Hacks
 ---
 
 Gérard, chief engineer at Airbus Defence & Space, will be sharing about Open Source Intelligence and how the WebLab approach is used to efficiently mine the web.

--- a/content/post/2014-09-12-friday-hacks-75.md
+++ b/content/post/2014-09-12-friday-hacks-75.md
@@ -3,6 +3,8 @@ author: Joey
 date: 2014-09-12T15:08:08.000Z
 title: 'Friday Hacks #75, September 12'
 url: /2014/09/friday-hacks-75
+categories:
+  - Friday Hacks
 ---
 
 Learn about machine learning this week! Shamraz will share about using ML in geography and Shawn will show you how to use ML with scikit-learn.

--- a/content/post/2014-09-19-friday-hacks-76.md
+++ b/content/post/2014-09-19-friday-hacks-76.md
@@ -3,6 +3,8 @@ author: Joey
 date: 2014-09-19T16:56:01.000Z
 title: 'Friday Hacks #76, September 19'
 url: /2014/09/friday-hacks-76
+categories:
+  - Friday Hacks
 ---
 
 ... let's play a game. Solve programming challenges this week at Friday Hacks, with a twist – shortest solutions win! JavaScript, Python and others accepted for Code Golf.

--- a/content/post/2014-10-03-friday-hacks-77.md
+++ b/content/post/2014-10-03-friday-hacks-77.md
@@ -3,6 +3,8 @@ author: Joey
 date: 2014-10-03T00:50:00.000Z
 title: 'Friday Hacks #77, October 3'
 url: /2014/10/friday-hacks-77
+categories:
+  - Friday Hacks
 ---
 
 At this week's session, find out about how autonomous underwater vehicles work! Alex will be sharing about control systems, computer vision with openCV, acoustic localization and autonomous mission control.

--- a/content/post/2014-10-10-friday-hacks-78.md
+++ b/content/post/2014-10-10-friday-hacks-78.md
@@ -3,6 +3,8 @@ author: Joey
 date: 2014-10-10T16:33:44.000Z
 title: 'Friday Hacks #78, October 10'
 url: /2014/10/friday-hacks-78
+categories:
+  - Friday Hacks
 ---
 
 This week's Friday Hacks is about cybercrime and NFC security by Vicky, Palo Alto Networks engineer, and Jeremias, NUS student, respectively!

--- a/content/post/2014-10-17-friday-hacks-79.md
+++ b/content/post/2014-10-17-friday-hacks-79.md
@@ -3,6 +3,8 @@ author: Joey
 date: 2014-10-17T16:29:44.000Z
 title: 'Friday Hacks #79, October 17'
 url: /2014/10/friday-hacks-79
+categories:
+  - Friday Hacks
 ---
 
 Meet Palantir at next week's Friday Hacks!

--- a/content/post/2014-10-24-friday-hacks-80.md
+++ b/content/post/2014-10-24-friday-hacks-80.md
@@ -3,6 +3,8 @@ author: Joey
 date: 2014-10-24T14:28:44.000Z
 title: 'Friday Hacks #80, October 24'
 url: /2014/10/friday-hacks-80
+categories:
+  - Friday Hacks
 ---
 
 Get all your questions about internships answered at next week's Friday Hacks! There will be a Q&A session after.

--- a/content/post/2014-10-31-friday-hacks-81.md
+++ b/content/post/2014-10-31-friday-hacks-81.md
@@ -3,6 +3,8 @@ author: Joey
 date: 2014-10-31T11:58:30.000Z
 title: 'Friday Hacks #81, October 31'
 url: /2014/10/friday-hacks-81
+categories:
+  - Friday Hacks
 ---
 
 Ever written code only to realise later it doesn't work for some particular case? Find out about some common assumptions developers make and what to do instead!

--- a/content/post/2014-11-07-friday-hacks-82.md
+++ b/content/post/2014-11-07-friday-hacks-82.md
@@ -3,6 +3,8 @@ author: Joey
 date: 2014-11-07T18:05:44.000Z
 title: 'Friday Hacks #82, November 7'
 url: /2014/11/friday-hacks-82
+categories:
+  - Friday Hacks
 ---
 
 There's more to hacking than software – get started with electronics at this Friday Hacks! Everyone* walks away with their own noise synthesizers and one lucky attendee will win a Raspberry Pi!

--- a/content/post/2014-11-14-friday-hacks-83.md
+++ b/content/post/2014-11-14-friday-hacks-83.md
@@ -3,6 +3,8 @@ author: Joey
 date: 2014-11-14T18:05:44.000Z
 title: 'Friday Hacks #83, November 14'
 url: /2014/11/friday-hacks-83
+categories:
+  - Friday Hacks
 ---
 
 Join us for the last Friday Hacks of the semester this week! Find out what your peers have been up to, and take part in NUS Hackers' first Mystery Event! <strong>Please RSVP</strong> on <a href="https://www.facebook.com/events/368317163343825/">our Facebook event</a>. It'll help us in estimating numbers for the Mystery Event!

--- a/content/post/2015-01-15-friday-hacks-84.md
+++ b/content/post/2015-01-15-friday-hacks-84.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-01-15T16:10:25.000Z
 title: 'Friday Hacks #84, January 16'
 url: /2015/01/friday-hacks-84
+categories:
+  - Friday Hacks
 ---
 
 Welcome back! For the first Friday Hacks of the semester, we have Benjamin Tan,

--- a/content/post/2015-01-19-friday-hacks-85.md
+++ b/content/post/2015-01-19-friday-hacks-85.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-01-19T11:53:25.000Z
 title: 'Friday Hacks #85, January 23'
 url: /2015/01/friday-hacks-85
+categories:
+  - Friday Hacks
 ---
 
 This Friday, we'll be having Sundaravalli Shriram from PayPal speaking about an

--- a/content/post/2015-01-26-friday-hacks-86.md
+++ b/content/post/2015-01-26-friday-hacks-86.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-01-26T22:08:25.000Z
 title: 'Friday Hacks #86, January 30'
 url: /2015/01/friday-hacks-86
+categories:
+  - Friday Hacks
 ---
 
 We will be having two talks this Friday! One is on software (databases), the

--- a/content/post/2015-02-04-friday-hacks-87.md
+++ b/content/post/2015-02-04-friday-hacks-87.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-02-04T16:08:25.000Z
 title: 'Friday Hacks #87, February 6'
 url: /2015/02/friday-hacks-87
+categories:
+  - Friday Hacks
 ---
 
 This week's topic will be on an introduction to deep learning and neural networks by Shawn Tan. See you there!

--- a/content/post/2015-02-06-friday-hacks-88.md
+++ b/content/post/2015-02-06-friday-hacks-88.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-02-06T19:37:25.000Z
 title: 'Friday Hacks #88, February 13'
 url: /2015/02/friday-hacks-88
+categories:
+  - Friday Hacks
 ---
 
 Ever wanted to get involved in the tech/developer community but don't know where to

--- a/content/post/2015-03-03-friday-hacks-89.md
+++ b/content/post/2015-03-03-friday-hacks-89.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-03-03T10:37:25.000Z
 title: 'Friday Hacks #89, March 6'
 url: /2015/03/friday-hacks-89
+categories:
+  - Friday Hacks
 ---
 
 We're happy to have Haoyi, an engineer from Dropbox, speaking this week about the web

--- a/content/post/2015-03-16-friday-hacks-90.md
+++ b/content/post/2015-03-16-friday-hacks-90.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-03-16T10:37:25.000Z
 title: 'Friday Hacks #90, March 20'
 url: /2015/03/friday-hacks-90
+categories:
+  - Friday Hacks
 ---
 
 We'll be having two talks this week! The first will be about building developer

--- a/content/post/2015-03-24-friday-hacks-91.md
+++ b/content/post/2015-03-24-friday-hacks-91.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-03-24T10:37:25.000Z
 title: 'Friday Hacks #91, March 27'
 url: /2015/03/friday-hacks-91
+categories:
+  - Friday Hacks
 ---
 
 We'll have two talks this week: Chris (ZALORA) will be talking about how

--- a/content/post/2015-04-07-friday-hacks-92.md
+++ b/content/post/2015-04-07-friday-hacks-92.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-04-07T10:37:25.000Z
 title: 'Friday Hacks #92, April 10'
 url: /2015/04/friday-hacks-92
+categories:
+  - Friday Hacks
 ---
 
 We'll be having three security researchers from the Ministry of Home Affairs --

--- a/content/post/2015-04-13-friday-hacks-93.md
+++ b/content/post/2015-04-13-friday-hacks-93.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-04-13T10:37:25.000Z
 title: 'Friday Hacks #93, April 17'
 url: /2015/04/friday-hacks-93
+categories:
+  - Friday Hacks
 ---
 
 For the final Friday Hacks of the semester, we'll be having Melvin Zhang, lead architect from Cosmiqo International, and Mathieu Feulvarch, senior product architect from MyRepublic. See you!

--- a/content/post/2015-08-13-friday-hacks-94.md
+++ b/content/post/2015-08-13-friday-hacks-94.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-08-13T10:37:25.000Z
 title: 'Friday Hacks #94, August 21'
 url: /2015/08/friday-hacks-94
+categories:
+  - Friday Hacks
 ---
 
 Friday Hacks are back for this new academic year!

--- a/content/post/2015-08-22-friday-hacks-95.md
+++ b/content/post/2015-08-22-friday-hacks-95.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-08-22T10:37:25.000Z
 title: 'Friday Hacks #95, August 28'
 url: /2015/08/friday-hacks-95
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header venue="Seminar Room 2, School of Computing" date="August 28" >}}

--- a/content/post/2015-08-29-friday-hacks-96.md
+++ b/content/post/2015-08-29-friday-hacks-96.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-08-29T10:37:25.000Z
 title: 'Friday Hacks #96, Sept 4'
 url: /2015/08/friday-hacks-96
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header venue="Seminar Room 3, Town Plaza, University Town" date="Sept 4" >}}

--- a/content/post/2015-09-14-friday-hacks-97.md
+++ b/content/post/2015-09-14-friday-hacks-97.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-09-14T10:37:25.000Z
 title: 'Friday Hacks #97, Sept 18'
 url: /2015/09/friday-hacks-97
+categories:
+  - Friday Hacks
 ---
 
 Ever wondered how PayPal or other large companies scale their infrastructure to address large traffic? Ryan, a software engineer from PayPal, will be explaining different ways to do it.

--- a/content/post/2015-09-29-friday-hacks-98.md
+++ b/content/post/2015-09-29-friday-hacks-98.md
@@ -3,6 +3,8 @@ author: Chu-Ming
 date: 2015-09-29T00:14:25.000Z
 title: 'Friday Hacks #98, Oct 02'
 url: /2015/09/friday-hacks-98
+categories:
+  - Friday Hacks
 ---
 
 Members of SoC have no doubt used the SoC Printing app on Android/iOS before. Kheng Meng, a recent SoC graduate will be explaining the behind the scenes of the SoC Printing system as well as giving an introduction to Bluetooth Low Energy.

--- a/content/post/2015-10-05-friday-hacks-99.md
+++ b/content/post/2015-10-05-friday-hacks-99.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-10-05T00:14:25.000Z
 title: 'Friday Hacks #99, Oct 09'
 url: /2015/10/friday-hacks-99
+categories:
+  - Friday Hacks
 ---
 
 We're very happy to have two recent graduates of NUS School of Computing to speak at this week's Friday Hacks about a very important programming language construct: the parser. Omer will be introducing what monads are and how you can use them to build parsers, while Richard will give an overview about his FYP that lets you parse and evaluate C code inline in vim.

--- a/content/post/2015-10-14-friday-hacks-100.md
+++ b/content/post/2015-10-14-friday-hacks-100.md
@@ -3,6 +3,8 @@ author: Jeremias
 date: 2015-10-14T17:59:00.000Z
 title: 'Friday Hacks #100, Oct 16'
 url: /2015/10/friday-hacks-100
+categories:
+  - Friday Hacks
 ---
 
 NUS Hackers is celebrating our 100th Friday Hacks!

--- a/content/post/2015-10-20-friday-hacks-101.md
+++ b/content/post/2015-10-20-friday-hacks-101.md
@@ -3,6 +3,8 @@ author: Chu-Ming
 date: 2015-10-20T13:32:00.000Z
 title: 'Friday Hacks #101, Oct 23'
 url: /2015/10/friday-hacks-101
+categories:
+  - Friday Hacks
 ---
 
 Coming up in our 101th Friday Hacks, we have He Wei from Hopetechnik sharing on engineering solutions in his line of work as well as Dr. Swapan giving a talk about security issues and phishing.

--- a/content/post/2015-10-27-friday-hacks-102.md
+++ b/content/post/2015-10-27-friday-hacks-102.md
@@ -3,6 +3,8 @@ author: Chu-Ming
 date: 2015-10-27T19:32:00.000Z
 title: 'Friday Hacks #102, Oct 30'
 url: /2015/10/friday-hacks-102
+categories:
+  - Friday Hacks
 ---
 
 This week, our very own coreteam members will be sharing on their internship experiences overseas. Learn why you should do internships, how to choose and of course, how to get them! Ask questions of other students who have interned overseas at various companies including Facebook, Palantir, Apple, Twitter, Dropbox, and Viki.

--- a/content/post/2015-11-03-friday-hacks-103.md
+++ b/content/post/2015-11-03-friday-hacks-103.md
@@ -3,6 +3,8 @@ author: Chu-Ming
 date: 2015-11-03T19:19:00.000Z
 title: 'Friday Hacks #103, Nov 06'
 url: /2015/11/friday-hacks-103
+categories:
+  - Friday Hacks
 ---
 
 This week, we're focusing on education. Learn about the science of the mind and bring all your questions from engineering to machine learning to the director of engineering at Coursera.

--- a/content/post/2015-11-10-friday-hacks-104.md
+++ b/content/post/2015-11-10-friday-hacks-104.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2015-11-10T16:56:01.000Z
 title: 'Friday Hacks #104, November 13'
 url: /2015/11/friday-hacks-104
+categories:
+  - Friday Hacks
 ---
 
 It's the last Friday Hacks of the semester, and we'll be doing something

--- a/content/post/2016-01-18-friday-hacks-105.md
+++ b/content/post/2016-01-18-friday-hacks-105.md
@@ -3,6 +3,8 @@ author: Jingwen
 date: 2016-01-18T16:56:01.000Z
 title: 'Friday Hacks #105, January 22nd'
 url: /2016/01/friday-hacks-105
+categories:
+  - Friday Hacks
 ---
 
 Welcome back to a brand new semester! For our first Friday Hacks of the semester, we're having Fazli, a School of Computing student, talking about his homemade Roomba hack with Kinect and RPi.

--- a/content/post/2016-01-27-friday-hacks-106.md
+++ b/content/post/2016-01-27-friday-hacks-106.md
@@ -3,6 +3,8 @@ author: Varun
 date: 2016-01-27T00:00:01.000Z
 title: 'Friday Hacks #106, January 29th'
 url: /2016/01/friday-hacks-106
+categories:
+  - Friday Hacks
 ---
 
 For our second Friday Hacks of the semester, we're having Chee Aun, a web developer, talking about the side projects.

--- a/content/post/2016-02-08-friday-hacks-107.md
+++ b/content/post/2016-02-08-friday-hacks-107.md
@@ -3,6 +3,8 @@ author: Varun
 date: 2016-02-08T00:00:01.000Z
 title: 'Friday Hacks #107, February 12th'
 url: /2016/02/friday-hacks-107
+categories:
+  - Friday Hacks
 ---
 
 For our third Friday Hacks of the semester, we're having Eeshan and Shuvan, two PhD's attempting to commercialize Li-Fi technology.

--- a/content/post/2016-02-26-friday-hacks-108.md
+++ b/content/post/2016-02-26-friday-hacks-108.md
@@ -3,6 +3,8 @@ author: Varun
 date: 2016-02-26T00:00:01.000Z
 title: 'Friday Hacks #108, March 4th'
 url: /2016/02/friday-hacks-108
+categories:
+  - Friday Hacks
 ---
 
 For our fourth Friday Hacks of the semester, we're having Cheng Wei, a senior

--- a/content/post/2016-03-11-friday-hacks-109.md
+++ b/content/post/2016-03-11-friday-hacks-109.md
@@ -3,6 +3,8 @@ author: Varun
 date: 2016-03-11T00:37:23.000Z
 title: 'Friday Hacks #109, March 11'
 url: /2016/03/friday-hacks-109
+categories:
+  - Friday Hacks
 ---
 
 For our fifth Friday Hacks of the semester, we're having Jia Hao, an undergrad from SUTD to talk about his popular [nativefier](//github.com/jiahaog/nativefier) project.

--- a/content/post/2016-03-18-friday-hacks-110.md
+++ b/content/post/2016-03-18-friday-hacks-110.md
@@ -3,6 +3,8 @@ author: Varun
 date: 2016-03-18T15:36:00.000Z
 title: 'Friday Hacks #110, March 18'
 url: /2016/03/friday-hacks-110
+categories:
+  - Friday Hacks
 ---
 
 For our sixth Friday Hacks of the semester, we’re having Jordan Dea-Mattson speak about [Wobe's](https://wobe.io) system architecture and how it uniquely addresses the issues of building robust, scalable, and secure mobile applications in hostile environments.

--- a/content/post/2016-04-01-friday-hacks-111.md
+++ b/content/post/2016-04-01-friday-hacks-111.md
@@ -3,6 +3,8 @@ author: Varun
 date: 2016-04-01T16:07:20.000Z
 title: 'Friday Hacks #111, April 1'
 url: /2016/04/friday-hacks-111
+categories:
+  - Friday Hacks
 ---
 
 It's going to be an epic security themed Friday this week. There will be two talks followed by a Q/A with Jeff Moss, founder of Black Hat & DEF CON!

--- a/content/post/2016-04-08-friday-hacks-112.md
+++ b/content/post/2016-04-08-friday-hacks-112.md
@@ -3,6 +3,8 @@ author: Varun
 date: 2016-04-08T11:41:31.000Z
 title: 'Friday Hacks #112, April 8'
 url: /2016/04/friday-hacks-112
+categories:
+  - Friday Hacks
 ---
 
 For our second last Friday Hacks of the semester, we're inviting Omer and Jason to tell us more about implementing compilers and programming languages. Join us for this programming languages themed talk.

--- a/content/post/2016-04-15-friday-hacks-113.md
+++ b/content/post/2016-04-15-friday-hacks-113.md
@@ -3,6 +3,8 @@ author: Varun
 date: 2016-04-15T22:25:55.000Z
 title: 'Friday Hacks #113, April 15'
 url: /2016/04/friday-hacks-113
+categories:
+  - Friday Hacks
 ---
 
 For our final Friday Hacks this semester, we’re inviting Melvin from [Cosmiqo](//cosmiqo.com/) and Jimeno and Alvin from [iDA Labs](https://www.ida.gov.sg/Programmes-Partnership/Store/IDA-Labs) Engineers.

--- a/content/post/2016-08-19-friday-hacks-114.md
+++ b/content/post/2016-08-19-friday-hacks-114.md
@@ -3,6 +3,8 @@ author: Advay Pal
 date: 2016-08-19T17:17:49.000Z
 title: 'Friday Hacks #114, August 19'
 url: /2016/08/friday-hacks-114
+categories:
+  - Friday Hacks
 ---
 
 <em>In the jargon of the computer programmer, a hacker is someone who strives to solve problems in elegant and ingenious ways.</em>

--- a/content/post/2016-08-26-friday-hacks-115.md
+++ b/content/post/2016-08-26-friday-hacks-115.md
@@ -3,6 +3,8 @@ author: Advay Pal
 date: 2016-08-26T12:22:16.000Z
 title: 'Friday Hacks #115, August 26'
 url: /2016/08/friday-hacks-115
+categories:
+  - Friday Hacks
 ---
 
 This week, we have Hongyi from IDA and Haoyi from Dropbox, to speak about some the work they do and the challenges they face while doing so. See you there!

--- a/content/post/2016-09-02-friday-hacks-116.md
+++ b/content/post/2016-09-02-friday-hacks-116.md
@@ -3,6 +3,8 @@ author: Advay Pal
 date: 2016-09-02T02:06:45.000Z
 title: 'Friday Hacks #116, September 2'
 url: /2016/09/friday-hacks-116
+categories:
+  - Friday Hacks
 ---
 
 This week, our very own coreteam members will be sharing their internship experiences locally and overseas!

--- a/content/post/2016-09-09-friday-hacks-117.md
+++ b/content/post/2016-09-09-friday-hacks-117.md
@@ -3,6 +3,8 @@ author: Advay Pal
 date: 2016-09-09T18:47:01.000Z
 title: 'Friday Hacks #117, September 9'
 url: /2016/09/friday-hacks-117
+categories:
+  - Friday Hacks
 ---
 
 This week, we have Melvin from Cosmiqo talking about Programs that play better than us, and Zhi An from our Coreteam talking about Chromelens. See you there!

--- a/content/post/2016-09-16-friday-hacks-118.md
+++ b/content/post/2016-09-16-friday-hacks-118.md
@@ -3,6 +3,8 @@ author: Advay Pal
 date: 2016-09-16T10:18:02.000Z
 title: 'Friday Hacks #118, September 16'
 url: /2016/09/friday-hacks-118
+categories:
+  - Friday Hacks
 ---
 
 This week we have Yos from PayPal and Yong Wen from IDA talking about some of the things they work on. See you there!

--- a/content/post/2016-09-30-friday-hacks-119.md
+++ b/content/post/2016-09-30-friday-hacks-119.md
@@ -3,6 +3,8 @@ author: Advay Pal
 date: 2016-09-30T21:02:22.000Z
 title: 'Friday Hacks #119, September 30'
 url: /2016/10/friday-hacks-119
+categories:
+  - Friday Hacks
 ---
 
 This week, we have Benjamin from DSO and James from nuTonomy, both talking about Autonomous Vehicles. See you there!

--- a/content/post/2016-10-07-friday-hacks-120.md
+++ b/content/post/2016-10-07-friday-hacks-120.md
@@ -3,6 +3,8 @@ author: Advay Pal
 date: 2016-10-07T14:53:50.000Z
 title: 'Friday Hacks #120, October 7'
 url: /2016/10/friday-hacks-120
+categories:
+  - Friday Hacks
 ---
 
 This week have Sean from Twitter talking about building scalable advertising platforms. See you there!

--- a/content/post/2016-10-14-friday-hacks-121.md
+++ b/content/post/2016-10-14-friday-hacks-121.md
@@ -3,6 +3,8 @@ author: Advay Pal
 date: 2016-10-14T21:49:38.000Z
 title: 'Friday Hacks #121, October 14'
 url: /2016/10/friday-hacks-121
+categories:
+  - Friday Hacks
 ---
 
 This week have Chuk from from NUS ISS and Yos from Paypal talking about JavaScript Promises, and GraphQL respectively. See you there!

--- a/content/post/2016-10-21-friday-hacks-122.md
+++ b/content/post/2016-10-21-friday-hacks-122.md
@@ -3,6 +3,8 @@ author: Advay Pal
 date: 2016-10-21T00:34:50.000Z
 title: 'Friday Hacks #122, October 21'
 url: /2016/10/friday-hacks-122
+categories:
+  - Friday Hacks
 ---
 
 This week is about some of the things our very own NUS students have been working on. We also have members from the NUSMods team talking about the latest things they've been doing to improve the timetable builder. See you there!

--- a/content/post/2016-10-28-friday-hacks-123.md
+++ b/content/post/2016-10-28-friday-hacks-123.md
@@ -3,6 +3,8 @@ author: Advay Pal
 date: 2016-10-28T09:09:57.000Z
 title: 'Friday Hacks #123, October 28'
 url: /2016/10/friday-hacks-123
+categories:
+  - Friday Hacks
 ---
 
 This week we have Jordan and Shekhar from TradeGecko talking about the benefits of using Go, and it's utility in a range of problem domains, including microservice based architectures. See you there!

--- a/content/post/2016-11-04-friday-hacks-124.md
+++ b/content/post/2016-11-04-friday-hacks-124.md
@@ -3,6 +3,8 @@ author: Advay Pal
 date: 2016-11-04T10:09:07.000Z
 title: 'Friday Hacks #124, November 4'
 url: /2016/11/friday-hacks-124
+categories:
+  - Friday Hacks
 ---
 
 It’s the last Friday Hacks of the semester, and we’ll be doing something different this time. Instead of the usual talks, we’ll be having a programming challenge this week, with a twist - shortest solutions win!

--- a/content/post/2017-01-20-friday-hacks-125.md
+++ b/content/post/2017-01-20-friday-hacks-125.md
@@ -3,6 +3,8 @@ author: Ramu
 date: 2017-01-20T15:36:04.000Z
 title: 'Friday Hacks #125, January 20'
 url: /2017/01/friday-hacks-125
+categories:
+  - Friday Hacks
 ---
 
 Friday Hacks is back for 2017! To kick off an exciting series this semester, we have two special guests delivering niche talks: Fazli Sapuan and Wang Chen. Fazli will be giving us an insight into the art of lock picking while Chen will be delving into machine learning. Read on to know more!

--- a/content/post/2017-02-03-friday-hacks-126.md
+++ b/content/post/2017-02-03-friday-hacks-126.md
@@ -3,6 +3,8 @@ author: Ramu
 date: 2017-02-03T00:52:39.000Z
 title: 'Friday Hacks #126, February 3'
 url: /2017/02/friday-hacks-126
+categories:
+  - Friday Hacks
 ---
 
 Hey folks, welcome back from the CNY break! Come join us this Friday to learn about computer security and collaborative tools! We will have Jethro Kuan sharing about collaborative text editing and Wang Leng sharing about cross site scripting. Read on to know more.

--- a/content/post/2017-02-10-friday-hacks-127.md
+++ b/content/post/2017-02-10-friday-hacks-127.md
@@ -3,6 +3,8 @@ author: Jethro Kuan
 date: 2017-02-10T00:26:25.000Z
 title: 'Friday Hacks #127, February 10'
 url: /2017/02/friday-hacks-127
+categories:
+  - Friday Hacks
 ---
 
 Come join us this Friday for our weekly Friday Hacks! We will have Ding Feng sharing about hardware hacking. Read on to know more.

--- a/content/post/2017-02-17-friday-hacks-128.md
+++ b/content/post/2017-02-17-friday-hacks-128.md
@@ -3,6 +3,8 @@ author: Ramu
 date: 2017-02-17T00:55:21.000Z
 title: 'Friday Hacks #128, February 17'
 url: /2017/02/friday-hacks-128
+categories:
+  - Friday Hacks
 ---
 
 We are excited to have Emil and Sunny speaking at this week's FH before we break for recess week. Check out more details below. See you there!

--- a/content/post/2017-03-10-friday-hacks-130.md
+++ b/content/post/2017-03-10-friday-hacks-130.md
@@ -3,6 +3,8 @@ author: Jethro Kuan
 date: 2017-03-10T18:32:21.000Z
 title: 'Friday Hacks #130, March 10'
 url: /2017/03/friday-hacks-130
+categories:
+  - Friday Hacks
 ---
 
 Hello folks, this week we're very excited to have Virgil Griffith over to speak about Bitcoin, Ethereum, the dark web as well as the exciting prospects of legaltech.

--- a/content/post/2017-03-17-friday-hacks-131.md
+++ b/content/post/2017-03-17-friday-hacks-131.md
@@ -3,6 +3,8 @@ author: Jethro Kuan
 date: 2017-03-17T09:52:54.000Z
 title: 'Friday Hacks #131, March 17'
 url: /2017/03/friday-hacks-131
+categories:
+  - Friday Hacks
 ---
 
 Hi folks! This week we are privileged to have one of the leading experts in high performance computing (he has his own law!), give a talk on the intricacies of math in computing. For more information, refer to the talk description.

--- a/content/post/2017-03-24-friday-hacks-132.md
+++ b/content/post/2017-03-24-friday-hacks-132.md
@@ -3,6 +3,8 @@ author: Jethro
 date: 2017-03-24T15:10:31.000Z
 title: 'Friday Hacks #132, March 24'
 url: /2017/03/friday-hacks-132
+categories:
+  - Friday Hacks
 ---
 
 Hello folks! Welcome back to Friday Hacks #132. This week we'll be having a talk by Abhilash, the creator of Bus Uncle, about how he built Singapore's most viral chatbot. After which, there will be a panel discussion headed by NUS Hackers Coreteam about how to maximize your summer.

--- a/content/post/2017-03-31-friday-hacks-133.md
+++ b/content/post/2017-03-31-friday-hacks-133.md
@@ -3,6 +3,8 @@ author: Ramu
 date: 2017-03-31T18:41:10.000Z
 title: 'Friday Hacks #133, March 31'
 url: /2017/04/friday-hacks-133
+categories:
+  - Friday Hacks
 ---
 
 Hey folks, join this special edition on cyber security to hear from Jeff Moss and Halvar Flake!

--- a/content/post/2017-04-07-friday-hacks-134.md
+++ b/content/post/2017-04-07-friday-hacks-134.md
@@ -3,6 +3,8 @@ author: Jethro Kuan
 date: 2017-04-07T18:44:10.000Z
 title: 'Friday Hacks #134, April 7'
 url: /2017/04/friday-hacks-134
+categories:
+  - Friday Hacks
 ---
 
 Welcome back to our last episode of Friday Hacks for this semester! This week we'll be having Peter over to talk about Nix and NixOS. Nix and its related technologies bring a radically different approach to server/container management and allows you to provision OS and software in repeatable and consistent ways. Also, if you're curious about row hammering as a means of exploitation, mentioned last Friday Hacks by Halvar, Vishnu will be sharing about it in detail in the second talk.

--- a/content/post/2017-08-25-friday-hacks-135.md
+++ b/content/post/2017-08-25-friday-hacks-135.md
@@ -3,6 +3,8 @@ title: 'Friday Hacks #135, August 25'
 date: 2017-08-16T11:05:43.042Z
 author: Suyash
 url: /2017/08/friday-hacks-135
+categories:
+  - Friday Hacks
 ---
 
 <em>(In the jargon of the computer programmer, a hacker is someone who strives to solve problems in elegant and ingenious ways.)</em>

--- a/content/post/2017-09-08-friday-hacks-136.md
+++ b/content/post/2017-09-08-friday-hacks-136.md
@@ -3,6 +3,8 @@ title: 'Friday Hacks #136, September 8'
 date: 2017-09-03T22:49:05.245Z
 author: Herbert
 url: /2017/09/friday-hacks-136
+categories:
+  - Friday Hacks
 ---
 
 Hi everyone! If you want to learn about cool projects done by NUS students and alumni, do come down to this Friday Hacks! For more information, refer to the description below.

--- a/content/post/2017-09-15-friday-hacks-137.md
+++ b/content/post/2017-09-15-friday-hacks-137.md
@@ -3,6 +3,8 @@ title: 'Friday Hacks #137, September 15'
 date: 2017-09-12T09:40:35.299Z
 author: Herbert
 url: /2017/09/friday-hacks-137
+categories:
+  - Friday Hacks
 ---
 
 This Friday, our very own coreteam members will be sharing their internship experiences both locally and overseas. We will also invite NUS students who have done internships in various companies.

--- a/content/post/2017-09-22-friday-hacks-138.md
+++ b/content/post/2017-09-22-friday-hacks-138.md
@@ -3,6 +3,8 @@ title: 'Friday Hacks #138, September 22'
 date: 2017-09-18T00:03:34.092Z
 author: Suyash
 url: /2017/09/friday-hacks-138
+categories:
+  - Friday Hacks
 ---
 
 This week we have Dmitry from PayPal who would be talking about functional programming with Scala. We also have Herbert, a Year 3 Computer Science and Mathematics undergraduate who will be talking about solving complex problems using SQL!

--- a/content/post/2017-10-06-friday-hacks-139.md
+++ b/content/post/2017-10-06-friday-hacks-139.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #139, October 6"
 date: 2017-09-29 23:01:13.231346
 author: Herbert
 url: /2017/10/friday-hacks-139
+categories:
+  - Friday Hacks
 ---
 
 This Friday, we have Hongyi from GovTech talking about the making and deployment of a Digital Parking App, and Mohammad from TradeGecko talking about Asynchronous Processing!

--- a/content/post/2017-10-13-friday-hacks-140.md
+++ b/content/post/2017-10-13-friday-hacks-140.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #140, October 13"
 date: 2017-10-06 12:35:34.446975
 author: Herbert
 url: /2017/10/friday-hacks-140
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header venue="The HANGAR by NUS Enterprise" date="October 13" >}}

--- a/content/post/2017-10-20-friday-hacks-141.md
+++ b/content/post/2017-10-20-friday-hacks-141.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #141, October 20"
 date: 2017-10-10 18:33:25.812044
 author: Herbert
 url: /2017/10/friday-hacks-141
+categories:
+  - Friday Hacks
 ---
 
 Hey everyone! This week, we have Feng Yuan from GovTech who will be talking about data science for the public good and Mattheus who will be talking about C++ Template Metaprogramming. See you there!

--- a/content/post/2017-10-27-friday-hacks-142.md
+++ b/content/post/2017-10-27-friday-hacks-142.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #142, October 27"
 date: 2017-10-22 17:47:58.542886
 author: Herbert
 url: /2017/10/friday-hacks-142
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header venue="SR3, Town Plaza, University Town, NUS" date="October 27" >}}

--- a/content/post/2017-11-03-friday-hacks-143.md
+++ b/content/post/2017-11-03-friday-hacks-143.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #143, November 3"
 date: 2017-10-31 00:09:44.471653
 author: Herbert
 url: /2017/11/friday-hacks-143
+categories:
+  - Friday Hacks
 ---
 
 Hey everyone! This week, we have E-Liang, a freshman, talking about his project Jarvis, which is a personal assistant. We also have Angad, a data scientist at Twitter Singapore talking about its stack. See you there!

--- a/content/post/2017-11-10-friday-hacks-144.md
+++ b/content/post/2017-11-10-friday-hacks-144.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #144, November 10"
 date: 2017-11-09 15:46:20.528772
 author: Herbert
 url: /2017/11/friday-hacks-144
+categories:
+  - Friday Hacks
 ---
 
 This Friday, our very own coreteam members will be sharing how to contribute to open-source projects. We also have other NUS students and Professor Damith who will be sharing about how they started contributing to open-source and how can one get started.

--- a/content/post/2017-11-17-friday-hacks-145.md
+++ b/content/post/2017-11-17-friday-hacks-145.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #145, November 17"
 date: 2017-11-14 11:58:29.561277
 author: Suyash
 url: /2017/11/friday-hacks-145
+categories:
+  - Friday Hacks
 ---
 
 It’s the last Friday Hacks of the semester, and to end it off with a blast (before we rush to catch up with all our webcasts during the reading week), instead of having talks, we will be having a Code Golf Challenge!

--- a/content/post/2018-01-19-friday-hacks-146.md
+++ b/content/post/2018-01-19-friday-hacks-146.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #146, January 19"
 date: 2018-01-15 23:40:57.337452
 author: Julius
 url: /2018/01/friday-hacks-146
+categories:
+  - Friday Hacks
 ---
 
 Hey Hackers, Friday Hacks is back again to kick-start the semester! What better way to start the semester than to learn about productivity hacks! We’ll attempt to tackle the age-old question: Vim or Emacs? 

--- a/content/post/2018-02-02-friday-hacks-147.md
+++ b/content/post/2018-02-02-friday-hacks-147.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #147, February 2"
 date: 2018-01-30 18:42:38.856544
 author: Julius
 url: /2018/02/friday-hacks-147
+categories:
+  - Friday Hacks
 ---
 
 

--- a/content/post/2018-02-09-friday-hacks-148.md
+++ b/content/post/2018-02-09-friday-hacks-148.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #148, February 9"
 date: 2018-02-06 21:16:41.764127
 author: Julius
 url: /2018/02/friday-hacks-148
+categories:
+  - Friday Hacks
 ---
 
 Hi hackers! This week we have Arun Sivakumar and Xyriz Tan who would be talking about making a mobile chatbots, 

--- a/content/post/2018-02-23-friday-hacks-149.md
+++ b/content/post/2018-02-23-friday-hacks-149.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #149, February 23"
 date: 2018-02-14 13:46:05.430967
 author: Julius
 url: /2018/02/friday-hacks-149
+categories:
+  - Friday Hacks
 ---
 
 Hi hackers, this week we have Parth Pokar from Maltem who would be talking about

--- a/content/post/2018-03-09-friday-hacks-150.md
+++ b/content/post/2018-03-09-friday-hacks-150.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #150, March 9"
 date: 2018-02-27 19:49:20.830103
 author: Julius
 url: /2018/03/friday-hacks-150
+categories:
+  - Friday Hacks
 ---
 
 Hi hackers, Friday Hacks is back after Recess Week. This time we have Joaquín from EF who will speak about Virtual World,

--- a/content/post/2018-03-16-friday-hacks-151.md
+++ b/content/post/2018-03-16-friday-hacks-151.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #151, March 16"
 date: 2018-03-12 22:02:30.815604
 author: Julius
 url: /2018/03/friday-hacks-151
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header venue="Seminar Room 1, Town Plaza, University Town (UT22-02-04A)" date="March 16" >}}

--- a/content/post/2018-03-23-friday-hacks-152.md
+++ b/content/post/2018-03-23-friday-hacks-152.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #152, March 23"
 date: 2018-03-14 12:31:23.850587
 author: Julius
 url: /2018/03/friday-hacks-152
+categories:
+  - Friday Hacks
 ---
 
 Hi Hackers, this week we have someone special coming over to speak at Friday Hacks: Jean-Baptiste Kempf, the lead developer for VLC Media Player and the VideoLAN President

--- a/content/post/2018-04-06-friday-hacks-153.md
+++ b/content/post/2018-04-06-friday-hacks-153.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #153, April 6"
 date: 2018-04-02 23:28:53.080834
 author: Julius
 url: /2018/04/friday-hacks-153
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header venue="The Hangar by NUS Enterprise" date="April 6" >}}

--- a/content/post/2018-04-13-friday-hacks-154.md
+++ b/content/post/2018-04-13-friday-hacks-154.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #154, April 13"
 date: 2018-04-09 10:11:38.333213
 author: Julius
 url: /2018/04/friday-hacks-154
+categories:
+  - Friday Hacks
 ---
 
 Hi hackers! Nowadays, one of the most important pieces of our modern web apps, be it in e-commerce, social media, or even search engines is a recommender system -- and this is what our speakers this week from Nurture.AI and Shopee will be speaking about this week.

--- a/content/post/2018-08-24-friday-hacks-155.md
+++ b/content/post/2018-08-24-friday-hacks-155.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #155, August 24"
 date: 2018-08-19 15:55:43.213765
 author: E-Liang
 url: /2018/08/friday-hacks-155
+categories:
+  - Friday Hacks
 ---
 
 <em>In the jargon of the computer programmer, a hacker is someone who strives to solve problems in elegant and ingenious ways.</em>

--- a/content/post/2018-08-31-friday-hacks-156.md
+++ b/content/post/2018-08-31-friday-hacks-156.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #156, August 31"
 date: 2018-08-25 11:29:47.833139
 author: E-Liang
 url: /2018/08/friday-hacks-156
+categories:
+  - Friday Hacks
 ---
 
 Hi Hackers,

--- a/content/post/2018-09-07-friday-hacks-157.md
+++ b/content/post/2018-09-07-friday-hacks-157.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #157, September 7"
 date: 2018-09-05 09:09:18.941319
 author: E-Liang
 url: /2018/09/friday-hacks-157
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2018-09-13-friday-hacks-158.md
+++ b/content/post/2018-09-13-friday-hacks-158.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #158, September 14"
 date: 2018-09-13 09:42:07.412787
 author: E-Liang
 url: /2018/09/friday-hacks-158
+categories:
+  - Friday Hacks
 ---
 
 This Friday is a special one. An AI expert will be coming down to share about cutting-edge AI trends and applications. Also, our very own coreteam members will be sharing their internship experiences both locally and overseas. We will also invite NUS students who have done internships in various companies.

--- a/content/post/2018-09-21-friday-hacks-159.md
+++ b/content/post/2018-09-21-friday-hacks-159.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #159, September 21"
 date: 2018-09-19 22:23:38.681482
 author: E-Liang
 url: /2018/09/friday-hacks-159
+categories:
+  - Friday Hacks
 ---
 
 Hello Hackers!

--- a/content/post/2018-10-12-friday-hacks-160.md
+++ b/content/post/2018-10-12-friday-hacks-160.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #160, October 12"
 date: 2018-10-09 12:49:14.204546
 author: E-Liang
 url: /2018/10/friday-hacks-160
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2018-10-19-friday-hacks-161.md
+++ b/content/post/2018-10-19-friday-hacks-161.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #161, October 19"
 date: 2018-10-16 11:44:55.016900
 author: E-Liang
 url: /2018/10/friday-hacks-161
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2018-10-26-friday-hacks-162.md
+++ b/content/post/2018-10-26-friday-hacks-162.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #162, October 26"
 date: 2018-10-23 08:12:38.071876
 author: E-Liang
 url: /2018/10/friday-hacks-162
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2018-11-02-friday-hacks-163.md
+++ b/content/post/2018-11-02-friday-hacks-163.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #163, November 2"
 date: 2018-11-01 10:41:09.276579
 author: E-Liang
 url: /2018/11/friday-hacks-163
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2018-11-09-friday-hacks-164.md
+++ b/content/post/2018-11-09-friday-hacks-164.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #164, November 9"
 date: 2018-11-07 11:45:57.755226
 author: E-Liang
 url: /2018/11/friday-hacks-164
+categories:
+  - Friday Hacks
 ---
 
 Hello Hackers!

--- a/content/post/2018-11-11-friday-hacks-165.md
+++ b/content/post/2018-11-11-friday-hacks-165.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #165, November 16"
 date: 2018-11-15 07:35:29.561277
 author: E-Liang
 url: /2018/11/friday-hacks-165
+categories:
+  - Friday Hacks
 ---
 
 It’s the last Friday Hacks of the semester, and to end it off with a blast (before we rush to catch up with all our webcasts during the reading week), instead of having talks, we will be having a Code Golf Challenge!

--- a/content/post/2019-01-25-friday-hacks-166.md
+++ b/content/post/2019-01-25-friday-hacks-166.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #166, January 25"
 date: 2019-01-18 04:28:52.468824
 author: Hao Wei
 url: /2019/01/friday-hacks-166
+categories:
+  - Friday Hacks
 ---
 
 Friday Hacks is back for the new semester! Join us for the pizza, stay for the code and hacks, and leave with new friends and ideas.

--- a/content/post/2019-02-01-friday-hacks-167.md
+++ b/content/post/2019-02-01-friday-hacks-167.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #167, February 1"
 date: 2019-01-28 16:07:45.493718
 author: Hao Wei
 url: /2019/02/friday-hacks-167
+categories:
+  - Friday Hacks
 ---
 
 Join us for a short session before the lunar new year!

--- a/content/post/2019-02-15-friday-hacks-168.md
+++ b/content/post/2019-02-15-friday-hacks-168.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #168, February 15"
 date: 2019-02-10 04:07:03.183830
 author: Hao Wei
 url: /2019/02/friday-hacks-168
+categories:
+  - Friday Hacks
 ---
 
 We're back from the lunar new year break!

--- a/content/post/2019-02-22-friday-hacks-169.md
+++ b/content/post/2019-02-22-friday-hacks-169.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #169, February 22"
 date: 2019-02-16 23:43:45.274398
 author: Hao Wei
 url: /2019/02/friday-hacks-169
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2019-03-15-friday-hacks-170.md
+++ b/content/post/2019-03-15-friday-hacks-170.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #170, March 15"
 date: 2019-03-09 23:53:25.677914
 author: Hao Wei
 url: /2019/03/friday-hacks-170
+categories:
+  - Friday Hacks
 ---
 
 We're back from recess week! Hope everyone had a good break and that midterms went well.

--- a/content/post/2019-03-22-friday-hacks-171.md
+++ b/content/post/2019-03-22-friday-hacks-171.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #171, March 22"
 date: 2019-03-18 02:57:42.441722
 author: Hao Wei
 url: /2019/03/friday-hacks-171
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2019-03-29-friday-hacks-172.md
+++ b/content/post/2019-03-29-friday-hacks-172.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #172, March 29"
 date: 2019-03-25 19:22:40.070776
 author: Hao Wei
 url: /2019/03/friday-hacks-172
+categories:
+  - Friday Hacks
 ---
 
 Back to The HANGAR once more this semester!

--- a/content/post/2019-04-05-friday-hacks-173.md
+++ b/content/post/2019-04-05-friday-hacks-173.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #173, April 5"
 date: 2019-03-31 21:32:23.814624
 author: Hao Wei
 url: /2019/04/friday-hacks-173
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2019-04-12-friday-hacks-174.md
+++ b/content/post/2019-04-12-friday-hacks-174.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #174, April 12"
 date: 2019-04-02 10:34:18.549671
 author: Hao Wei
 url: /2019/04/friday-hacks-174
+categories:
+  - Friday Hacks
 ---
 
 This is the last Friday Hacks of the semester! Join us for one last session before finals.

--- a/content/post/2019-08-16-friday-hacks-175.md
+++ b/content/post/2019-08-16-friday-hacks-175.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #175, August 16: Welcome Tea"
 date: 2019-08-14 10:34:18.549671
 author: Raynold Ng
 url: /2019/08/friday-hacks-175
+categories:
+  - Friday Hacks
 ---
 
 <em>In the jargon of the computer programmer, a hacker is someone who strives to solve problems in elegant and ingenious ways.</em>

--- a/content/post/2019-08-23-friday-hacks-176.md
+++ b/content/post/2019-08-23-friday-hacks-176.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #176, August 23: Functional Data Structures & Data Pipeline
 date: 2019-08-17 22:39:00.552692
 author: Raynold Ng
 url: /2019/08/friday-hacks-176
+categories:
+  - Friday Hacks
 ---
 
 

--- a/content/post/2019-08-23-friday-hacks-177.md
+++ b/content/post/2019-08-23-friday-hacks-177.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #177, August 30: Project Intern"
 date: 2019-08-26 22:39:00.552692
 author: Raynold Ng
 url: /2019/08/friday-hacks-177
+categories:
+  - Friday Hacks
 ---
 
 

--- a/content/post/2019-08-30-friday-hacks-178.md
+++ b/content/post/2019-08-30-friday-hacks-178.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #178, September 6: Building NUSMods and finding evil NPM pa
 date: 2019-08-30 20:06:32.593550
 author: Raynold Ng
 url: /2019/08/friday-hacks-178
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2019-08-30-friday-hacks-179.md
+++ b/content/post/2019-08-30-friday-hacks-179.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #179, September 13: High-throughout blockchain & Open Sourc
 date: 2019-08-30 20:06:33
 author: Raynold Ng
 url: /2019/08/friday-hacks-179
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2019-08-30-friday-hacks-180.md
+++ b/content/post/2019-08-30-friday-hacks-180.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #180, September 20: Good Practices & Efficient Mobile Multi
 date: 2019-08-30 20:06:34
 author: Raynold Ng
 url: /2019/08/friday-hacks-180
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2019-10-03-friday-hacks-181.md
+++ b/content/post/2019-10-03-friday-hacks-181.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #181, Oct 11: Nudging and Machine Learning with Databricks"
 date: 2019-10-03 20:06:34
 author: Raynold Ng
 url: /2019/10/friday-hacks-181
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2019-10-11-friday-hacks-182.md
+++ b/content/post/2019-10-11-friday-hacks-182.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #182, Oct 18: SRE and Voice Based Cancer Genomics"
 date: 2019-10-11 20:06:34
 author: Raynold Ng
 url: /2019/10/friday-hacks-182
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2019-10-20-friday-hacks-183.md
+++ b/content/post/2019-10-20-friday-hacks-183.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #183, Oct 25: Runtime schedulers and aspect sentiment analy
 date: 2019-10-20 00:00:00
 author: Raynold Ng
 url: /2019/10/friday-hacks-183
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2019-10-20-friday-hacks-184.md
+++ b/content/post/2019-10-20-friday-hacks-184.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #184, Nov 1: Production Data Pipelines and Open Source at F
 date: 2019-10-31 00:00:00
 author: Raynold Ng
 url: /2019/10/friday-hacks-184
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2019-11-01-friday-hacks-185.md
+++ b/content/post/2019-11-01-friday-hacks-185.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #185, Nov 8: Proofs for scaling blockchain computation and 
 date: 2019-11-01 00:00:00
 author: Raynold Ng
 url: /2019/11/friday-hacks-185
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2019-11-07-friday-hacks-186.md
+++ b/content/post/2019-11-07-friday-hacks-186.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #186, Nov 15: Code Golf"
 date: 2019-11-08 00:00:00
 author: Raynold Ng
 url: /2019/11/friday-hacks-186
+categories:
+  - Friday Hacks
 ---
 
 It’s the last Friday Hacks of the semester, and to end it off with a blast (before we rush to catch up with all our webcasts during the reading week), instead of having talks, we will be having a Code Golf Challenge!

--- a/content/post/2020-01-31-friday-hacks-187.md
+++ b/content/post/2020-01-31-friday-hacks-187.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #187, Jan 31: Analytics in the Real World & Server-Side Req
 date: 2020-01-31 00:00:00
 author: Chaitanya Baranwal
 url: /2020/01/friday-hacks-187
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2020-02-07-friday-hacks-188.md
+++ b/content/post/2020-02-07-friday-hacks-188.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #188, Feb 7: Under the Hood of Stripe.js, and RSA in the Re
 date: 2020-02-07 00:00:00
 author: Chaitanya Baranwal
 url: /2020/02/friday-hacks-188
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2020-02-14-friday-hacks-189.md
+++ b/content/post/2020-02-14-friday-hacks-189.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #189, Feb 14: Stream Processing, and Making Real-Time Games
 date: 2020-02-14 00:00:00
 author: Chaitanya Baranwal
 url: /2020/02/friday-hacks-189
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2020-08-21-friday-hacks-190.md
+++ b/content/post/2020-08-21-friday-hacks-190.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #190, August 21: Welcome Tea"
 date: 2020-08-05 10:34:18.549671
 author: Christopher Goh
 url: /welcometea2020
+categories:
+  - Friday Hacks
 ---
 
 <em>In the jargon of the computer programmer, a hacker is someone who strives to solve problems in elegant and ingenious ways.</em>

--- a/content/post/2020-08-28-friday-hacks-191.md
+++ b/content/post/2020-08-28-friday-hacks-191.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #191, August 28: Project Intern"
 date: 2020-08-28 19:00:00
 author: Chaitanya Baranwal
 url: /2020/08/friday-hacks-191
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, August 28 at 7:00pm<br />

--- a/content/post/2020-09-04-friday-hacks-192.md
+++ b/content/post/2020-09-04-friday-hacks-192.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #192, September 4: Everything about Randomness, and Reinfor
 date: 2020-09-04 19:00:00
 author: Chaitanya Baranwal
 url: /2020/09/friday-hacks-192
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 4 at 7:00pm<br />

--- a/content/post/2020-09-18-friday-hacks-193.md
+++ b/content/post/2020-09-18-friday-hacks-193.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #193, September 18"
 date: 2020-09-11 00:00:00
 author: Chaitanya Baranwal
 url: /2020/09/friday-hacks-193
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 18 at 7:00pm<br />

--- a/content/post/2020-10-09-friday-hacks-194.md
+++ b/content/post/2020-10-09-friday-hacks-194.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #194, October 9"
 date: 2020-10-01 00:00:00
 author: Chaitanya Baranwal
 url: /2020/10/friday-hacks-194
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 9 at 7:00pm<br />

--- a/content/post/2020-10-16-friday-hacks-195.md
+++ b/content/post/2020-10-16-friday-hacks-195.md
@@ -4,6 +4,8 @@ date: 2020-10-09 00:00:00
 author: Chaitanya Baranwal
 url: /2020/10/friday-hacks-195
 summary: Changing Walls on Jane Street - converting static models to self-adjusting ones, and a tryst with Kubernetes!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 16 at 7:00pm<br />

--- a/content/post/2020-10-23-friday-hacks-196.md
+++ b/content/post/2020-10-23-friday-hacks-196.md
@@ -4,6 +4,8 @@ date: 2020-10-13 00:00:00
 author: Chaitanya Baranwal
 url: /2020/10/friday-hacks-196
 summary: Tune to know how Stripe.js works behind the scenes, and the nuts-and-bolts details of our favourite Leetcode language - Python.
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 23 at 7:00pm<br />

--- a/content/post/2020-11-06-friday-hacks-197.md
+++ b/content/post/2020-11-06-friday-hacks-197.md
@@ -4,6 +4,8 @@ date: 2020-10-30 00:00:00
 author: Chaitanya Baranwal
 url: /2020/11/friday-hacks-197
 summary: This week, we'll be talking about using AI to optimize revenue and uptake in tourism, and using Kafka to handle 2 billion triggers a day!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, November 6 at 7:00pm<br />

--- a/content/post/2021-01-22-friday-hacks-198.md
+++ b/content/post/2021-01-22-friday-hacks-198.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #198, January 22"
+title: "Friday Hacks #198, January 22: How Fluminu(r)s was Built & URA Space Out Project"
 date: 2021-01-19 00:00:00
 author: Mayank Keoliya
 url: /2021/01/friday-hacks-198
 summary: Tired of LumiNUS? Want to know which malls are the most crowded? Tune in for the first Friday Hack of the year, with talks about Fluminus, a hack built by a f-rustrated student, and SpaceOut, the a webapp that gives you info on crowds at malls, hawker centres and hospitals.
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, January 22 at 7:00pm<br />
@@ -16,11 +18,9 @@ summary: Tired of LumiNUS? Want to know which malls are the most crowded? Tune i
 
 Fluminus and Fluminurs are CLI tools to automate downloading files from LumiNUS, the new learning management system that NUS uses to replace IVLE. Unlike IVLE, there is no open, easily accessible API available to students. This talk will describe how I built Fluminus and Fluminurs in spite of this limitation.
 
-
 #### Speaker Profile:
 
 Julius is a recently graduated Computer Science undergrad and an NUS Hackers coreteam member for the past 3 years. His interests include functional programming and distributed systems. Outside of computer science, he also enjoys Space Exploration, History, and Music Theory (reflected in his favourite games: Kerbal Space Program and Europa Universalis IV)
-
 
 ### URA - Space Out Project
 

--- a/content/post/2021-02-05-friday-hacks-199.md
+++ b/content/post/2021-02-05-friday-hacks-199.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #199, February 5"
+title: "Friday Hacks #199, February 5: Relational Programming in miniKanren & Implementing a Kanren from the Ground Up"
 date: 2021-01-25 00:00:00
 author: Mayank Keoliya
 url: /2021/01/friday-hacks-199
 summary: Think OOP is passé? Love declarative code? Join the authors of the "The Reasoned Schemer" in the wonder of logic programming.
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, February 5 at 7:00pm<br />
@@ -16,11 +18,9 @@ summary: Think OOP is passé? Love declarative code? Join the authors of the "Th
 
 Relational programming is a paradigm in which programs are written as mathematical relations, with no distinction between "inputs" and "outputs". Relational programs are extremely flexible---in effect, every use of a relational program is equivalent to a synthesis problem. I will introduce the idea of relational programming, give examples of interesting relational programs in the [miniKanren](http://minikanren.org/) language, and show how this very small language can be used to implement interesting program synthesis tools, such as [Barliman](https://github.com/webyrd/Barliman).
 
-
 #### Speaker Profile:
 
 Will Byrd is a scientist at the Hugh Kaul Precision Medicine Institute at the University of Alabama at Birmingham. He is co-author of both editions of 'The Reasoned Schemer', and one of the creators of the miniKanren relational programming language. He is also co-running this year's Scheme and Functional Programming Workshop -- please submit a paper! :)
-
 
 ### Implementing a Kanren from the Ground Up
 

--- a/content/post/2021-02-19-friday-hacks-200.md
+++ b/content/post/2021-02-19-friday-hacks-200.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #200, February 19"
+title: "Friday Hacks #200, February 19: Is No-Code the future of Software Development and 10 Things We Learnt at Y Combinator"
 date: 2021-02-08 00:00:00
 author: Mayank Keoliya
 url: /2021/02/friday-hacks-200
 summary: What if you could “code” by drawing pictures? How does a Silicon Valley summer pan out for a NOC alumnus’ startup? Join us to answer these, and more!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, February 19 at 7:00pm<br />
@@ -22,16 +24,13 @@ Join Edward Hutchins, a product management consultant at ThoughtWorks, in this s
 - What are the implications of No-Code on software developers?
 - What is No-Code's place in the future of software development?
 
-
 #### Speaker Profile:
 
 Edward is a lead consultant product manager at ThoughtWorks. He has over 10 years experience working in the tech industry, from startups, to banks, and his own companies.
 
 Now he uses his diverse experience (he has been a developer, business analyst, project manager, and product manager) to help others transform their businesses and build awesome products.
 
-
 ### 10 Things We Learnt at Y Combinator
-
 
 #### Talk Description:
 

--- a/content/post/2021-03-12-friday-hacks-201.md
+++ b/content/post/2021-03-12-friday-hacks-201.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #201, March 12"
+title: "Friday Hacks #201, March 12: DSL for Computational Law & ML and ML Ops at Google"
 date: 2021-03-08 00:00:00
 author: Mayank Keoliya
 url: /2021/03/friday-hacks-201
-summary: Ever wondered how Gmail detects spam mail (or fails to, like Archipelago invitations)? Or whether you can use code to describe a legal contract? Tune in this week to hear from Vincent @ Google, and Meng @ Legalese! 
+summary: Ever wondered how Gmail detects spam mail (or fails to, like Archipelago invitations)? Or whether you can use code to describe a legal contract? Tune in this week to hear from Vincent @ Google, and Meng @ Legalese!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, March 12 at 7:00pm<br />
@@ -16,14 +18,11 @@ summary: Ever wondered how Gmail detects spam mail (or fails to, like Archipelag
 
 Singapore recently approved a $15M grant to fund development of opensource languages and libraries for computational law – a software stack which seeks to do for legal and qualitative reasoning what the spreadsheet has done for quantitative reasoning. This talk considers laws and contracts as a problem in computer science, and proposes a domain-specific language amenable to formal verification and other old-fashioned AI methods like constraint logic programming, answer set programming, model checking, LTL/CTL, and type theory.
 
-
 #### Speaker Profile:
 
 As a programming language enthusiast, Meng programs in TypeScript, Haskell, Prolog, Python, and Perl, with Emacs and VS Code. He studied computer science at upenn.edu, co-authored RFC4408, and co-founded a handful of startups including pobox.com, hackerspace.sg, and jfdi.asia, and legalese.com. His research in computational law has taken him to Stanford’s CodeX Center for Legal Informatics, Harvard’s Berkman–Klein center for Internet & Society, and Ca’Foscari University of Venice. He is presently principal investigator at SMU’s Centre for Computational Law. He lives in Joo Chiat with his partner Alexis Chun and two dogs, @iodoodle and @lyragroodle on Instagram.
 
-
-### ML & ML Ops @ Google 
-
+### ML & ML Ops @ Google
 
 #### Talk Description:
 
@@ -31,7 +30,7 @@ In this talk, Vincent, who works in the Trust & Safety team @ Google, will be di
 
 #### Speaker Profile:
 
-Vincent Tatan fights phishing with ML @ Google, using  advanced ML algorithms and MLOps to protect Chrome, Gmail and Android users against phishing attacks on vulnerable populations. Vincent is also a writer for Towards Data Science.
+Vincent Tatan fights phishing with ML @ Google, using advanced ML algorithms and MLOps to protect Chrome, Gmail and Android users against phishing attacks on vulnerable populations. Vincent is also a writer for Towards Data Science.
 
 In his free time, Vincent hacks on Kaggle and trains for triathlons or
 cycling trips.

--- a/content/post/2021-03-19-friday-hacks-202.md
+++ b/content/post/2021-03-19-friday-hacks-202.md
@@ -1,10 +1,12 @@
 ---
-title: "Friday Hacks #202, March 19"
+title: "Friday Hacks #202, March 19: It's a Ruby Friday Hack - with the creator of Ruby!"
 date: 2021-03-13 00:00:00
 author: Mayank Keoliya
 url: /2021/03/friday-hacks-202
 summary: It's a Ruby Friday Hack - with the creator of Ruby!
 
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, March 19 at 7:00pm SGT (11am GMT) <br />
@@ -15,7 +17,7 @@ summary: It's a Ruby Friday Hack - with the creator of Ruby!
 
 #### Speaker Profile:
 
-Yukhiro Matsumoto (better known as Matz) is the chief designer of the Ruby programming language, and its interpreter. He's also the Chief Architect of Ruby at the cloud platform-as-a-service company Heroku. Matz released Ruby 3.0 last Christmas - after a marathon 5 year development period. He's contributed immensely to the open source community and Ruby in general, leading to the MINASWAN adage in the Ruby community - "Matz is nice and so we are nice." 
+Yukhiro Matsumoto (better known as Matz) is the chief designer of the Ruby programming language, and its interpreter. He's also the Chief Architect of Ruby at the cloud platform-as-a-service company Heroku. Matz released Ruby 3.0 last Christmas - after a marathon 5 year development period. He's contributed immensely to the open source community and Ruby in general, leading to the MINASWAN adage in the Ruby community - "Matz is nice and so we are nice."
 
 ### What's Love Got to Do With It? Ruby and Sentiment Analysis
 
@@ -28,6 +30,5 @@ We will take a dive into understanding how this technology works, and apply it i
 #### Speaker Profile:
 
 Ben Greenberg is a second career developer who previously spent a decade in the fields of adult education, community organizing and non-profit management. He works as a developer advocate for Nexmo, the Vonage API Platform by day and experiments with open source projects at night. He writes regularly on the intersection of community development and tech. Originally from Southern California and a long time resident of New York City, Ben now resides near Tel Aviv, Israel.
-
 
 See you there!

--- a/content/post/2021-03-26-friday-hacks-203.md
+++ b/content/post/2021-03-26-friday-hacks-203.md
@@ -1,10 +1,12 @@
 ---
-title: "Friday Hacks #203, March 26"
+title: "Friday Hacks #203, March 26: Being hired as a Junior Dev & Disaster Recovery with Postman.gov.sg"
 date: 2021-03-13 00:01:00
 author: Mayank Keoliya
 url: /2021/03/friday-hacks-203
 summary:
 
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, March 26 at 7:00pm SGT (11am GMT) <br />
@@ -14,6 +16,7 @@ summary:
 ### Help! I Just Got Hired As a Junior Dev (WFH Edition)
 
 #### Talk Description:
+
 So you've gotten your first job or internship as a developer.
 
 Now what?

--- a/content/post/2021-08-03-friday-hacks-204.md
+++ b/content/post/2021-08-03-friday-hacks-204.md
@@ -5,6 +5,8 @@ author: Hao Wei
 url: /2021/08/friday-hacks-204
 aliases:
 - /welcometea2021
+categories:
+  - Friday Hacks
 ---
 
 <em>In the jargon of the computer programmer, a hacker is someone who strives to solve problems in elegant and ingenious ways.</em>

--- a/content/post/2021-08-15-friday-hacks-205.md
+++ b/content/post/2021-08-15-friday-hacks-205.md
@@ -4,6 +4,8 @@ date: 2021-08-15 22:00:00.000000
 author: Zhang Ziqing
 url: /2021/08/friday-hacks-205
 summary: Come down for this Friday Hacks, and learn how to get good tech internships from all over the world.
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, August 20 at 7:00pm<br />

--- a/content/post/2021-08-23-friday-hacks-206.md
+++ b/content/post/2021-08-23-friday-hacks-206.md
@@ -4,6 +4,8 @@ date: 2021-08-23 22:00:00.000000
 author: Zhang Ziqing
 url: /2021/08/friday-hacks-206
 summary: Join us either online or offline, and tune in to talks about Video Streaming & Observability in Production!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, August 27 at 7:00pm<br />

--- a/content/post/2021-08-29-friday-hacks-207.md
+++ b/content/post/2021-08-29-friday-hacks-207.md
@@ -4,6 +4,8 @@ date: 2021-08-29 22:00:00.000000
 author: Zhang Ziqing
 url: /2021/09/friday-hacks-207
 summary:
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 03 at 7:00pm<br />

--- a/content/post/2021-09-03-friday-hacks-208.md
+++ b/content/post/2021-09-03-friday-hacks-208.md
@@ -4,6 +4,8 @@ date: 2021-09-03 21:30:00.000000
 author: Zhang Ziqing
 url: /2021/09/friday-hacks-208
 summary:
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 10 at 7:00pm<br />

--- a/content/post/2021-09-11-friday-hacks-209.md
+++ b/content/post/2021-09-11-friday-hacks-209.md
@@ -4,6 +4,8 @@ date: 2021-09-12 21:30:00.000000
 author: Zhang Ziqing
 url: /2021/09/friday-hacks-209
 summary:
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 17 at 7:00pm<br />

--- a/content/post/2021-10-12-friday-hacks-210.md
+++ b/content/post/2021-10-12-friday-hacks-210.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #210"
+title: "Friday Hacks #210: Introduction to Test-Driven Development"
 date: 2021-10-12 14:50:00.000000
 author: Zhang Ziqing
 url: /2021/10/friday-hacks-210
 summary: Introduction to Test-Driven Development
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 15 at 7:00pm<br />

--- a/content/post/2021-10-17-friday-hacks-211.md
+++ b/content/post/2021-10-17-friday-hacks-211.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #211"
+title: "Friday Hacks #211: Explore quantum computing through gaming, and Linters in Dart"
 date: 2021-10-17 19:50:00.000000
 author: Zhang Ziqing
 url: /2021/10/friday-hacks-211
 summary: Explore quantum computing through gaming, and Linters in Dart
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 22 at **5:00pm**<br />

--- a/content/post/2021-10-25-friday-hacks-212.md
+++ b/content/post/2021-10-25-friday-hacks-212.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #212"
+title: "Friday Hacks #212: Crisis Management Modelling and Simulation, and Managing Server Resources for SoC Modules"
 date: 2021-10-25 13:50:00.000000
 author: Zhang Ziqing
 url: /2021/10/friday-hacks-212
 summary: Crisis Management Modelling and Simulation, and Managing Server Resources for SoC Modules
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 29 at 7:00pm <br />

--- a/content/post/2021-11-01-friday-hacks-213.md
+++ b/content/post/2021-11-01-friday-hacks-213.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #213"
+title: "Friday Hacks #213: Security at ExpressVPN, and Five Tips To Make You A Better Engineer"
 date: 2021-11-01 22:50:00.000000
 author: Zhang Ziqing
 url: /2021/11/friday-hacks-213
 summary: Security at ExpressVPN, and Five Tips To Make You A Better Engineer
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, November 5 at 7:00pm <br />

--- a/content/post/2022-01-21-friday-hacks-214.md
+++ b/content/post/2022-01-21-friday-hacks-214.md
@@ -4,6 +4,8 @@ date: 2022-01-15 00:35:42.301617
 author: Simon Julian Lauw
 url: /2022/01/friday-hacks-214
 summary: GPU.js and Hack&Roll 2022 Projects
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2022-01-28-friday-hacks-215.md
+++ b/content/post/2022-01-28-friday-hacks-215.md
@@ -4,6 +4,8 @@ date: 2022-01-25 13:38:40.448852
 author: Simon Julian Lauw
 url: /2022/01/friday-hacks-215
 summary: Reinforcement Learning and Linear Complexity Transformers
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2022-02-11-friday-hacks-216.md
+++ b/content/post/2022-02-11-friday-hacks-216.md
@@ -4,6 +4,8 @@ date: 2022-02-08 10:17:59.009151
 author: Simon Julian Lauw
 url: /2022/02/friday-hacks-216
 summary: NUSMods and Automated Piracy
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2022-02-18-friday-hacks-217.md
+++ b/content/post/2022-02-18-friday-hacks-217.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #217: Devtool Startup in SV and Ktor"
 date: 2022-02-12 16:02:20.329003
 author: Simon Julian Lauw
 url: /2022/02/friday-hacks-217
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2022-03-11-friday-hacks-218.md
+++ b/content/post/2022-03-11-friday-hacks-218.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #218: How to Build a Career Moat"
 date: 2022-03-09 18:25:53.167463
 author: Simon Julian Lauw
 url: /2022/03/friday-hacks-218
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2022-03-18-friday-hacks-219.md
+++ b/content/post/2022-03-18-friday-hacks-219.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #219: Zero Knowledge Secret Sharing and Two Weeks Too Slow"
 date: 2022-03-17 17:54:01.245862
 author: Simon Julian Lauw
 url: /2022/03/friday-hacks-219
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2022-03-25-friday-hacks-220.md
+++ b/content/post/2022-03-25-friday-hacks-220.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #220, March 25: Intro to Geospatial Data Science and A Happ
 date: 2022-03-24 16:50:28.214191
 author: Simon Julian Lauw
 url: /2022/03/friday-hacks-220
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2022-04-01-friday-hacks-221.md
+++ b/content/post/2022-04-01-friday-hacks-221.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #221, April 1: Why bet the company on Elm for both front an
 date: 2022-03-29 12:24:43.696220
 author: Simon Julian Lauw
 url: /2022/04/friday-hacks-221
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2022-04-08-friday-hacks-222.md
+++ b/content/post/2022-04-08-friday-hacks-222.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #222, April 8: AI & the Metaverse and FoodDX"
 date: 2022-04-08 11:05:27.840839
 author: Simon Julian Lauw
 url: /2022/04/friday-hacks-222
+categories:
+  - Friday Hacks
 ---
 
 {{< friday_hack_header

--- a/content/post/2022-08-12-friday-hacks-223.md
+++ b/content/post/2022-08-12-friday-hacks-223.md
@@ -5,6 +5,8 @@ author: Shen Yi Hong
 url: /2022/08/friday-hacks-223
 aliases:
   - /welcometea2022
+categories:
+  - Friday Hacks
 ---
 
 <em>In the jargon of the computer programmer, a hacker is someone who strives to solve problems in elegant and ingenious ways.</em>

--- a/content/post/2022-08-19-friday-hacks-224.md
+++ b/content/post/2022-08-19-friday-hacks-224.md
@@ -5,6 +5,8 @@ author: Shen Yi Hong
 url: /2022/08/friday-hacks-224
 sponsors:
     - hangar
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, August 19 at 7:00pm SGT<br />

--- a/content/post/2022-08-26-friday-hacks-225.md
+++ b/content/post/2022-08-26-friday-hacks-225.md
@@ -5,6 +5,8 @@ author: Shen Yi Hong
 url: /2022/08/friday-hacks-225
 sponsors:
     - hangar
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, August 26 at 7:00pm SGT<br />

--- a/content/post/2022-09-02-friday-hacks-226.md
+++ b/content/post/2022-09-02-friday-hacks-226.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #226, September 02: AI with Human-in-the-Loop and Engineeri
 date: 2022-08-27 10:12:14.1235
 author: Shen Yi Hong
 url: /2022/09/friday-hacks-226
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 02 at 7:00pm SGT<br />

--- a/content/post/2022-09-09-friday-hacks-227.md
+++ b/content/post/2022-09-09-friday-hacks-227.md
@@ -5,6 +5,8 @@ author: Shen Yi Hong
 url: /2022/09/friday-hacks-227
 sponsors:
     - hangar 
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 09 at 7:00pm SGT<br />

--- a/content/post/2022-09-16-friday-hacks-228.md
+++ b/content/post/2022-09-16-friday-hacks-228.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #228, September 16: Cats, Burrito, and Laziness and Moderni
 date: 2022-09-11 16:13:14.5144
 author: Shen Yi Hong
 url: /2022/09/friday-hacks-228
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 16 at 7:00pm SGT<br />

--- a/content/post/2022-10-07-friday-hacks-229.md
+++ b/content/post/2022-10-07-friday-hacks-229.md
@@ -5,6 +5,8 @@ author: Shen Yi Hong
 url: /2022/10/friday-hacks-229
 sponsors:
     - hangar
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 7 at 7:00pm SGT<br />

--- a/content/post/2022-10-14-friday-hacks-230.md
+++ b/content/post/2022-10-14-friday-hacks-230.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #230, October 14: The Making of Precursor: AMA and Post-qua
 date: 2022-10-08 12:13:14.5144
 author: Shen Yi Hong
 url: /2022/10/friday-hacks-230
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 14 at 7:00pm SGT<br />

--- a/content/post/2022-10-28-friday-hacks-231.md
+++ b/content/post/2022-10-28-friday-hacks-231.md
@@ -3,6 +3,8 @@ title: "Friday Hacks #231, October 28: Prototyping a (tile grouting) robot at ho
 date: 2022-10-21 12:13:14.5144
 author: Shen Yi Hong
 url: /2022/10/friday-hacks-231
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 28 at 7:00pm SGT<br />

--- a/content/post/2022-11-04-friday-hacks-232.md
+++ b/content/post/2022-11-04-friday-hacks-232.md
@@ -5,6 +5,8 @@ author: Shen Yi Hong
 url: /2022/11/friday-hacks-232
 sponsors:
     - hangar
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, November 4 at 7:00pm SGT<br />

--- a/content/post/2023-01-27-friday-hacks-233.md
+++ b/content/post/2023-01-27-friday-hacks-233.md
@@ -5,6 +5,8 @@ author: Toh Li Heng
 url: /2023/01/friday-hacks-233
 sponsors:
     - hangar
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, January 27 at 7:00pm SGT<br />

--- a/content/post/2023-02-03-friday-hacks-234.md
+++ b/content/post/2023-02-03-friday-hacks-234.md
@@ -6,6 +6,8 @@ url: /2023/02/friday-hacks-234
 summary: From idea to revenue and some cool hacks from Hack&Roll 2023.
 sponsors:
     - hangar
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, February 03 at 7:00pm SGT<br />

--- a/content/post/2023-02-10-friday-hacks-235.md
+++ b/content/post/2023-02-10-friday-hacks-235.md
@@ -6,6 +6,8 @@ url: /2023/02/friday-hacks-235
 summary: More cool hacks from Hack&Roll 2023.
 sponsors:
     - hangar
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, February 10 at 7:00pm SGT<br />

--- a/content/post/2023-02-17-friday-hacks-236.md
+++ b/content/post/2023-02-17-friday-hacks-236.md
@@ -6,6 +6,8 @@ url: /2023/02/friday-hacks-236
 summary: Fuzzing Data Engines with SQLancer and creating Battery-Free IoT Devices
 sponsors:
     - hangar
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, February 17 at 7:00pm SGT<br />

--- a/content/post/2023-03-10-friday-hacks-237.md
+++ b/content/post/2023-03-10-friday-hacks-237.md
@@ -6,6 +6,8 @@ url: /2023/03/friday-hacks-237
 summary: Customisable laptops and what are the hardships of building hardware startups
 sponsors:
     - hangar
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, March 10 at 7:00pm SGT<br />

--- a/content/post/2023-03-17-friday-hacks-238.md
+++ b/content/post/2023-03-17-friday-hacks-238.md
@@ -6,6 +6,8 @@ url: /2023/03/friday-hacks-238
 summary: How Linux boosted productivity and career opportunities and PhD applications
 sponsors:
     - hangar
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, March 17 at 6:45pm SGT<br />

--- a/content/post/2023-03-24-friday-hacks-239.md
+++ b/content/post/2023-03-24-friday-hacks-239.md
@@ -4,6 +4,8 @@ date: 2023-03-23 12:25:15.5144
 author: Toh Li Heng
 url: /2023/03/friday-hacks-239
 summary: Abusing sensor data and modular IoT transaction platform
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, March 24 at 7:00pm SGT<br />

--- a/content/post/2023-03-24-friday-hacks-240.md
+++ b/content/post/2023-03-24-friday-hacks-240.md
@@ -6,6 +6,8 @@ url: /2023/03/friday-hacks-240
 summary: Code Golf!
 sponsors:
     - hangar
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, March 31 at 7:00pm SGT<br />

--- a/content/post/2023-08-18-friday-hacks-241.md
+++ b/content/post/2023-08-18-friday-hacks-241.md
@@ -6,6 +6,8 @@ url: /2023/08/friday-hacks-241
 summary: Join us at NUS Hackers - we organise weekly events to get you up and running with workshops, talks, hackathons and more!
 aliases:
   - /welcometea2023
+categories:
+  - Friday Hacks
 ---
 
 <em>In the jargon of the computer programmer, a hacker is someone who strives to solve problems in elegant and ingenious ways.</em>

--- a/content/post/2023-08-25-friday-hacks-242.md
+++ b/content/post/2023-08-25-friday-hacks-242.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #242, August 25"
+title: "Friday Hacks #242, August 25: Design philosophy and side projects with ChatGPT"
 date: 2023-08-25 12:25:15.5144
 author: Parth Gujar
 url: /2023/08/friday-hacks-242
 summary: On design philosophy and side projects with ChatGPT
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, August 25 at 7:00pm SGT<br />
@@ -24,7 +26,7 @@ Designers design, and engineers build. This is the current state of things in th
 
 Chester, a product engineer at Mobbin (a UI/UX reference library for designers), challenges norms and shares his engineering philosophy. Also, he works on Design Spells, a newsletter showcasing design details 🪄
 
-## 2) 2 Side Projects: Pair Coding with ChatGPT 
+## 2) 2 Side Projects: Pair Coding with ChatGPT
 
 With the help of ChatGPT, Wei Gao assisted her designer friend in creating animations for her portfolio site and developing a web app for generating Instagram images. She'll discuss her collaborative experience with ChatGPT and insights gained.
 

--- a/content/post/2023-09-08-friday-hacks-243.md
+++ b/content/post/2023-09-08-friday-hacks-243.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #243, September 8"
+title: "Friday Hacks #243, September 8: Engineering for Latency, Technical Hurdles in Automated Trading and Kubernetes"
 date: 2023-09-03 12:25:15.5144
 author: Parth Gujar
 url: /2023/09/friday-hacks-243
 summary: Engineering with latency and using Kubernetes
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 8 at 7:00pm SGT<br />

--- a/content/post/2023-09-15-friday-hacks-244.md
+++ b/content/post/2023-09-15-friday-hacks-244.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #244, September 15"
+title: "Friday Hacks #244, September 15: Building your own apps and launching a tech startup"
 date: 2023-09-08 12:25:15.5144
 author: Parth Gujar
 url: /2023/09/friday-hacks-244
 summary: Building your own apps and launching a tech startup
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 15 at 7:00pm SGT<br />
@@ -33,4 +35,3 @@ Learn the journey of building a tech startup for modern Incident Response Manage
 ### Speaker Profile
 
 Ildar is currently a principal engineer at Grafana Labs. Prior to this, he co-founded Amixr.IO in 2019 and worked at Cisco as a software engineer.
-

--- a/content/post/2023-09-22-friday-hacks-245.md
+++ b/content/post/2023-09-22-friday-hacks-245.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #245, September 22"
+title: "Friday Hacks #245, September 22: Online Algorithms Made Easy"
 date: 2023-09-18 12:25:15.5144
 author: Parth Gujar
 url: /2023/09/friday-hacks-245
 summary: Online algorithms
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 22 at 7:00pm SGT<br />
@@ -16,7 +18,7 @@ _If you are unable to come join us physically, you are welcome to join us [onlin
 
 <img src="/img/2023/fh/245.jpg" alt="Friday Hacks #245 Poster" /><br />
 
-## Online Algorithms Made Easy 
+## Online Algorithms Made Easy
 
 The world around us is constantly changing and at Jane Street we're receiving new data at a rate faster than ever before. When running complicated models that contain many parameters, reacting to a change in a single parameter by restarting the entire model is impractical. Instead, Jane Street makes use of ideas from research into self-adjusting computation in order to turn static models into models that can be partially recomputed in an efficient way. This talk will introduce the idea of self-adjusting computation and show how it can be used to make online algorithms easy to run and update efficiently.
 
@@ -25,4 +27,3 @@ The world around us is constantly changing and at Jane Street we're receiving ne
 Lester Tan is a software engineer at Jane Street. He graduated with a degree in Computer Science from NUS in 2019, and is currently working in the Singapore office.
 
 👋 See you there!
-

--- a/content/post/2023-10-13-friday-hacks-246.md
+++ b/content/post/2023-10-13-friday-hacks-246.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #246, October 13"
+title: "Friday Hacks #246, October 13: Saving infrastracture costs by colocating and programming languages research"
 date: 2023-10-09 12:25:15.5144
 author: Parth Gujar
 url: /2023/10/friday-hacks-246
 summary: On saving infrastracture costs by colocating and programming languages research
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 13 at 7:00pm SGT<br />
@@ -33,4 +35,3 @@ Learn why PL is an exciting research area for hackers, with fun projects like bu
 Kiran is a PhD student at NUS. His research focuses on developing newer and better tools for automated formal verification.
 
 👋 See you there!
-

--- a/content/post/2023-10-20-friday-hacks-247.md
+++ b/content/post/2023-10-20-friday-hacks-247.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #247, October 20"
+title: "Friday Hacks #247, October 20: Building an AI startup and creating a stable ABI for Rust"
 date: 2023-10-13 12:25:15.5144
 author: Parth Gujar
 url: /2023/10/friday-hacks-247
 summary: On building an AI startup and creating a stable ABI for Rust
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 20 at 7:00pm SGT<br />
@@ -41,4 +43,3 @@ Pierre Avital, PhD, is a core contributor to Eclipse Zenoh, a networking middlew
 After using Rust professionally since 1.28 (in the olden times before async/await), he's decided to make dynamic linkage more friendly for Rustaceans.
 
 👋 See you there!
-

--- a/content/post/2023-10-27-friday-hacks-248.md
+++ b/content/post/2023-10-27-friday-hacks-248.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #248, October 27"
+title: "Friday Hacks #248, October 27: On LLMs, app hacks, and DuckDB"
 date: 2023-10-21 12:25:15.5144
 author: Parth Gujar
 url: /2023/10/friday-hacks-248
 summary: On LLMs, app hacks, and DuckDB
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 27 at 6:00pm SGT<br />
@@ -45,4 +47,3 @@ Learn about DuckDB, an in-process analytical database management system. DuckDB 
 Gábor Szárnyas is Developer Relations Advocate at DuckDB Labs. He obtained his PhD in software engineering in 2019 and spent 3 years as a post-doctoral researcher at CWI in Amsterdam, working on graph data management techniques.
 
 👋 See you there!
-

--- a/content/post/2023-11-03-friday-hacks-249.md
+++ b/content/post/2023-11-03-friday-hacks-249.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #249, November 3"
+title: "Friday Hacks #249, November 3: Quantum theory and its applications"
 date: 2023-10-29 12:25:15.5144
 author: Parth Gujar
 url: /2023/11/friday-hacks-249
 summary: Quantum theory and its applications
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, November 3 at 6:00pm SGT<br />
@@ -27,4 +29,3 @@ In the second half of the talk, technical details about quantum theory will cove
 Clive Cenxin Aw and Zaw Lin Htoo are PhD students from a theoretical group at the Centre of Quantum Technologies. Clive's research interests lie in comparing the reversal of classical processes and that of quantum processes, especially in connection to what might be said about entanglement, memory and thermodynamics in the quantum regime. Lin works primarily on methods to certify that “something quantum” is really happening in simple systems, like pendulums and spinning tops, with a secondary interest in theoretical and numerical studies of quantum devices.
 
 👋 See you there!
-

--- a/content/post/2024-02-02-friday-hacks-251.md
+++ b/content/post/2024-02-02-friday-hacks-251.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #251, February 2"
+title: "Friday Hacks #251, February 2: Multiplayer Game Programming with Mirror & Hack&Roll Winning Game Projects"
 date: 2024-02-02 12:25:15.5144
 author: Wong Kok Rui
 url: /2024/02/friday-hacks-251
 summary: On Multiplayer Game Development and Hack&Roll 2024 Game Projects
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, February 2 at 7:00pm SGT<br />
@@ -31,4 +33,3 @@ Calvin Fong is part of the team that created Hack&Roll 2024’s Most Entertainin
 Santasila Bryan Kusno and Ella Yovita Suwibowo are part of a team that won Top 8 at Hack&Roll 2024. They and their teammates Anabelle Kyra and Tan En-miin Elizabeth created the game [Sign Racer](https://devpost.com/software/the-furious-of-sign-racer).
 
 👋 See you there!
-

--- a/content/post/2024-02-14-friday-hacks-252.md
+++ b/content/post/2024-02-14-friday-hacks-252.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #252, February 16"
+title: "Friday Hacks #252, February 16: Hack&Roll 2024 Winning Projects Lightning Talks"
 date: 2024-02-14 12:25:15.5144
 author: Wong Kok Rui
 url: /2024/02/friday-hacks-252
 summary: More Hack&Roll 2024 Winning Projects!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, February 16 at 7:00pm SGT<br />
@@ -20,17 +22,19 @@ summary: More Hack&Roll 2024 Winning Projects!
 This week, we’re featuring more of our awesome winning projects from Hack&Roll 2024!
 
 ### 1. speedruNUS
+
 speedruNUS is a Telegram bot that ranks all CS / CU modules for you to choose from after an interactive personality quiz to allow you to graduate without stress! speedruNUS was made by Tan Yi Guan, Kleon Ang, and Kenneth Hong and was a Top 8 Project at Hack&Roll 2024!
 
 ### 2. Luna AI
+
 Luna AI is a multilingual voice agent for government services, answering queries for the public and helping call centre professionals edit information and identify customers who require help. Luna AI was made by Ching Ming Yuan, Ryan Loh, Yong Khee Hou, and Benjamin Christopher Toh and was a Top 8 Project at Hack&Roll 2024!
 
 ### 3. Cod Captcha
+
 Captchas are the most annoying part of browsing the internet. However, with Cod Captcha, we have created a solution to this problem by making and it even MUCH HARDER than it needs to be! Cod Captcha was made by Addison Chua, Yee Jia Chen, and Jimmy Lew and was a Top 8 Project at Hack&Roll 2024!
 
-### 4. Brainrot Plus 
+### 4. Brainrot Plus
+
 Brainrot Plus takes a piece of text, whether it's lecture notes, book chapters, or complex concepts, and utilizes AI to transform it into easy-to-understand reels. Brainrot Plus was made by Javier Lim, Justin Lim, Loy Juncheng, and Lin Yicheng and was a Top 8 Project at Hack&Roll 2024!
 
-
 👋 See you there!
-

--- a/content/post/2024-02-20-friday-hacks-253.md
+++ b/content/post/2024-02-20-friday-hacks-253.md
@@ -4,6 +4,8 @@ date: 2024-02-20 12:25:15.5144
 author: Wong Kok Rui
 url: /2024/02/friday-hacks-253
 summary: On Cryptocurrency Arbitrage and MySQL Internals!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, February 23 at 7:00pm SGT<br />

--- a/content/post/2024-03-10-friday-hacks-254.md
+++ b/content/post/2024-03-10-friday-hacks-254.md
@@ -4,6 +4,8 @@ date: 2024-03-10 12:25:15.5144
 author: Wong Kok Rui
 url: /2024/03/friday-hacks-254
 summary: On Music Technology and Time Synchronization!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, March 15 at 7:00pm SGT<br />

--- a/content/post/2024-03-17-friday-hacks-255.md
+++ b/content/post/2024-03-17-friday-hacks-255.md
@@ -4,6 +4,8 @@ date: 2024-03-17 12:25:15.5144
 author: Wong Kok Rui
 url: /2024/03/friday-hacks-255
 summary: On Prototypes and Reimagined Road Charges!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, March 22 at 7:00pm SGT<br />

--- a/content/post/2024-03-22-friday-hacks-256.md
+++ b/content/post/2024-03-22-friday-hacks-256.md
@@ -4,6 +4,8 @@ date: 2024-03-22 12:25:15.5144
 author: Wong Kok Rui
 url: /2024/03/friday-hacks-256
 summary: On Livestreams and Principal Component Analysis!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, April 5 at 7:00pm SGT<br />

--- a/content/post/2024-04-01-friday-hacks-257.md
+++ b/content/post/2024-04-01-friday-hacks-257.md
@@ -4,6 +4,8 @@ date: 2024-04-01 12:25:15.5144
 author: Wong Kok Rui
 url: /2024/04/friday-hacks-257
 summary: On the New XOR Problem and Becoming Data Driven!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, April 12 at 7:00pm SGT<br />

--- a/content/post/2024-08-15-friday-hacks-259.md
+++ b/content/post/2024-08-15-friday-hacks-259.md
@@ -4,6 +4,8 @@ date: 2024-08-17 21:25:15.5144
 author: Chua Jun Yu
 url: /2024/08/friday-hacks-259
 summary: Discover how to apply software engineering to solve security problems and learn more about continuations!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, August 23 at 7:00pm SGT<br />

--- a/content/post/2024-08-25-friday-hacks-260.md
+++ b/content/post/2024-08-25-friday-hacks-260.md
@@ -4,6 +4,8 @@ date: 2024-08-25 21:25:15.5144
 author: Chua Jun Yu
 url: /2024/08/friday-hacks-260
 summary: Learn more about practical prompt engineering techniques to get the most out of LLMs!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, August 30 at 7:00pm SGT<br />

--- a/content/post/2024-09-02-friday-hacks-261.md
+++ b/content/post/2024-09-02-friday-hacks-261.md
@@ -4,6 +4,8 @@ date: 2024-09-02 14:00:15.5144
 author: Chua Jun Yu
 url: /2024/09/friday-hacks-261
 summary: Discover more about Purple A11y, an open-source tool to automate accessibility testing, and hear about the various challenges faced when migrating a legacy codebase to the web!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 6 at 7:00pm SGT<br />

--- a/content/post/2024-09-09-friday-hacks-262.md
+++ b/content/post/2024-09-09-friday-hacks-262.md
@@ -4,6 +4,8 @@ date: 2024-09-09 11:44:15.5144
 author: Chua Jun Yu
 url: /2024/09/friday-hacks-262
 summary: Discover more about AI in Complex Adversarial Games and Sharing Secrets (with your friends)!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 13 at 7:00pm SGT<br />

--- a/content/post/2024-09-18-friday-hacks-263.md
+++ b/content/post/2024-09-18-friday-hacks-263.md
@@ -4,6 +4,8 @@ date: 2024-09-18 10:17:15.5144
 author: Chua Jun Yu
 url: /2024/09/friday-hacks-263
 summary: Hear more about the technical and non-technical lessons learnt from 2 decades of open source!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, September 20 at 7:00pm SGT<br />

--- a/content/post/2024-10-07-friday-hacks-264.md
+++ b/content/post/2024-10-07-friday-hacks-264.md
@@ -4,6 +4,8 @@ date: 2024-10-07 18:44:15.5144
 author: Chua Jun Yu
 url: /2024/10/friday-hacks-264
 summary: Discover more about using sophisticated MiTM attacks and learning about how machines as customers will affect business!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 11 at 7:00pm SGT<br />

--- a/content/post/2024-10-16-friday-hacks-265.md
+++ b/content/post/2024-10-16-friday-hacks-265.md
@@ -4,6 +4,8 @@ date: 2024-10-16 11:44:15.5144
 author: Chua Jun Yu
 url: /2024/10/friday-hacks-265
 summary: Discover how to get started on AI research as an undergraduate and how to engineer an application for scale!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 18 at 7:00pm SGT<br />

--- a/content/post/2024-10-24-friday-hacks-266.md
+++ b/content/post/2024-10-24-friday-hacks-266.md
@@ -4,6 +4,8 @@ date: 2024-10-23 11:44:15.5144
 author: Chua Jun Yu
 url: /2024/10/friday-hacks-266
 summary: Learn more about Operating Design for fast I/O and Music Content Identification!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, October 25 at 7:00pm SGT<br />

--- a/content/post/2024-11-04-friday-hacks-267.md
+++ b/content/post/2024-11-04-friday-hacks-267.md
@@ -4,6 +4,8 @@ date: 2024-11-04 11:44:15.5144
 author: Chua Jun Yu
 url: /2024/11/friday-hacks-267
 summary: Learn more about enhancing enterprise cybersecurity and Open-RMF for robotics!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, November 8 at 7:00pm SGT<br />

--- a/content/post/2024-11-13-friday-hacks-268.md
+++ b/content/post/2024-11-13-friday-hacks-268.md
@@ -4,6 +4,8 @@ date: 2024-11-13 11:44:15.5144
 author: Chua Jun Yu
 url: /2024/11/friday-hacks-268
 summary: Join us for the final Friday Hacks of AY24/25 Semester 1, featuring a fun series of quick ~20-minute lightning talks!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, November 15 at 7:00pm SGT<br />

--- a/content/post/2025-02-07-friday-hacks-269.md
+++ b/content/post/2025-02-07-friday-hacks-269.md
@@ -4,6 +4,8 @@ date: 2025-02-04 14:08:00.050096
 author: Justin Cheah
 url: /2025/02/friday-hacks-269
 summary: Join us for our first Friday Hacks of the semester, where we showcase exciting projects from H&R 2025!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, February 7 at 7:00pm SGT<br />

--- a/content/post/2025-02-13-friday-hacks-270.md
+++ b/content/post/2025-02-13-friday-hacks-270.md
@@ -4,6 +4,8 @@ date: 2025-02-07 00:08:00.050096
 author: Justin Cheah
 url: /2025/02/friday-hacks-270
 summary: Learn more about the technical systems that power Jane Street’s trading operations and the key roles CS graduates play in tackling complex challenges!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** <ins>Thursday</ins>, February 13 at 7:00pm SGT<br />

--- a/content/post/2025-02-21-friday-hacks-271.md
+++ b/content/post/2025-02-21-friday-hacks-271.md
@@ -4,6 +4,8 @@ date: 2025-02-18 00:08:00.050096
 author: Justin Cheah
 url: /2025/02/friday-hacks-271
 summary: Learn about Vite, Rust and the future of javascript tooling from the founder of VueJS, and how to move large amount of data around!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, February 21 at 7:00pm SGT<br />

--- a/content/post/2025-03-14-friday-hacks-272.md
+++ b/content/post/2025-03-14-friday-hacks-272.md
@@ -4,6 +4,8 @@ date: 2025-03-10 00:08:00.050096
 author: Justin Cheah
 url: /2025/03/friday-hacks-272
 summary: Learn about how AI can generate realistic financial data while ensuring privacy, and insights for navigating Cyber Threat Intelligence!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, March 14 at 7:00pm SGT<br />

--- a/content/post/2025-03-21-friday-hacks-273.md
+++ b/content/post/2025-03-21-friday-hacks-273.md
@@ -4,6 +4,8 @@ date: 2025-03-18 00:08:00.050096
 author: Justin Cheah
 url: /2025/03/friday-hacks-273
 summary: Learn more about how NUS Computing students are integrating technology with healthcare in Cambodia and the latest in post-quantum security
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, March 21 at 7:00pm SGT<br />

--- a/content/post/2025-04-04-friday-hacks-274.md
+++ b/content/post/2025-04-04-friday-hacks-274.md
@@ -4,6 +4,8 @@ date: 2025-04-01 00:08:00.050096
 author: Justin Cheah
 url: /2025/04/friday-hacks-274
 summary: Learn more about the principles of Android Platform Security, and how calculated risks are taken at Gojek!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, April 4 at 7:00pm SGT<br />

--- a/content/post/2025-04-04-friday-hacks-275.md
+++ b/content/post/2025-04-04-friday-hacks-275.md
@@ -4,6 +4,8 @@ date: 2025-04-09 00:08:00.050096
 author: Daren Tan
 url: /2025/04/friday-hacks-275
 summary: Learn more about DNA, Data & Debugging at Genomics, and how HCI contributes to Modern Health Practices!
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time:** Friday, April 11 at 7:00pm SGT<br />

--- a/content/post/2025-08-22-friday-hacks-277.md
+++ b/content/post/2025-08-22-friday-hacks-277.md
@@ -4,6 +4,8 @@ date: 2025-08-17 18:22:10.002392
 author: Prakamya Singh
 url: /2025/08/friday-hacks-277
 summary: Learn more about work in the field of evolutionary agents, and the strategic life of an order in a modern market.
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time**: Friday, August 22 at 7:00pm SGT<br />

--- a/content/post/2025-08-29-friday-hacks-278.md
+++ b/content/post/2025-08-29-friday-hacks-278.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #278, August 29"
+title: "Friday Hacks #278, August 29: TBC"
 date: 2025-08-22 00:08:00.050096
 author: Prakamya Singh
 url: /2025/08/friday-hacks-278
 summary: TBC
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time**: Friday, August 29 at 7:00pm SGT<br />
@@ -14,11 +16,12 @@ summary: TBC
 
 <img src="/img/2025/fh/278-1.jpeg" alt="Friday Hacks #278 Poster 1" /><br />
 
-
 ## 1) [TBC] Rewriting a Critical Payment Services in Rust
+
 _Description pending_
 
 ### Speaker Profile 🎙️️
+
 _Pending_
 <br /><br />
 

--- a/content/post/2025-09-05-friday-hacks-279.md
+++ b/content/post/2025-09-05-friday-hacks-279.md
@@ -1,9 +1,11 @@
 ---
-title: "Friday Hacks #279, September 5"
+title: "Friday Hacks #279, September 5: TBC"
 date: 2025-08-29 00:08:00.050096
 author: Prakamya Singh
 url: /2025/09/friday-hacks-279
 summary: TBC
+categories:
+  - Friday Hacks
 ---
 
 **Date/Time**: Friday, August 29 at 7:00pm SGT<br />
@@ -14,15 +16,16 @@ summary: TBC
 
 <img src="/img/2025/fh/279-1.jpeg" alt="Friday Hacks #279 Poster 1" /><br />
 
-
 ## 1) TBC
 
 <img src="/img/2025/fh/279-2.jpeg" alt="Friday Hacks #279 Poster 2" /><br />
 
 ## 2) Keeping Code Fresh: 20 Years of Lizard and Counting
+
 _Description pending_
 
 ### Speaker Profile 🎙️️
+
 _Pending_
 <br /><br />
 

--- a/content/post/2025-09-19-friday-hacks-281.md
+++ b/content/post/2025-09-19-friday-hacks-281.md
@@ -1,8 +1,10 @@
 ---
-title: "Friday Hacks #281, September 19"
+title: "Friday Hacks #281, September 19: TBC"
 date: 2025-09-12 00:08:00.050096
 author: Prakamya Singh
 url: /2025/09/friday-hacks-281
+categories:
+  - Friday Hacks
 summary: TBC
 ---
 
@@ -20,11 +22,9 @@ summary: TBC
 
 ## Talk Title TBC
 
-
 ### Speakers Profile 🎙️
 
 TBC
 <br /><br />
 
 👋 See you there!
-

--- a/content/post/2025-10-10-friday-hacks-282.md
+++ b/content/post/2025-10-10-friday-hacks-282.md
@@ -9,7 +9,7 @@ summary: TBC
 ---
 
 **Date/Time:** October 10 at 7:00pm SGT<br />
-**Venue:** <a href="https://nusmods.com/venues/COM3-01-23">Seminar Room 14, COM3-01-23, NUS</a><br />
+**Venue:** <a href="https://nusmods.com/venues/COM3-01-21">Seminar Room 12, COM3-01-21, NUS</a><br />
 **Sign-up Link:** [Sign-up here](https://hckr.cc/fh-282-signup)<br />
 
 > **Food 🍕 and Drinks 🧋 will be served!**

--- a/content/post/2025-10-10-friday-hacks-282.md
+++ b/content/post/2025-10-10-friday-hacks-282.md
@@ -1,0 +1,39 @@
+---
+title: "Friday Hacks #282, October 10: TBC"
+date: 2025-10-10 00:08:00.050096
+author: Daren Tan
+url: /2025/10/friday-hacks-282
+categories:
+  - Friday Hacks
+summary: TBC
+---
+
+**Date/Time:** October 10 at 7:00pm SGT<br />
+**Venue:** <a href="https://nusmods.com/venues/COM3-01-23">Seminar Room 14, COM3-01-23, NUS</a><br />
+**Sign-up Link:** [Sign-up here](https://hckr.cc/fh-282-signup)<br />
+
+> **Food 🍕 and Drinks 🧋 will be served!**
+
+<img src="/img/2025/fh/282-1.jpeg" alt="Friday Hacks #282 Poster 1" /><br />
+
+## 1) TBC
+
+_Description pending_
+
+### Speaker Profile 🎙️️
+
+_Pending_
+<br /><br />
+
+<img src="/img/2025/fh/282-2.jpeg" alt="Friday Hacks #282 Poster 2" /><br />
+
+## 2) TBC (Vercel)
+
+_Description pending_
+
+### Speaker Profile 🎙️️
+
+_Pending_
+<br /><br />
+
+👋 See you there!

--- a/data/friday_hacks/friday_hacks_2526_1.yml
+++ b/data/friday_hacks/friday_hacks_2526_1.yml
@@ -37,7 +37,13 @@ hacks:
         from: Jane Street
   - nohack: Recess Week
   - nohack: Midterms
-  - nospeaker: true
+  - venue: <a href="https://nusmods.com/venues/COM3-01-21">Seminar Room 12, COM3-01-21, NUS</a>
+    blog_post: /2025/10/friday-hacks-282
+    topics:
+      - speaker: TBC
+        title: TBC
+      - speaker: Vercel
+        title: TBC
   - nospeaker: true
   - nospeaker: true
   - nospeaker: true

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -2,7 +2,15 @@
 <div class="container">
   <div class="row">
     <div>
-      <h1>View All {{ .Title }} Posts</h1>
+      {{ if eq .Title "Categories" }}
+      <h1>All {{ .Title }}</h1>
+      {{ range .Pages }}
+      <h3>
+        <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+      </h3>
+      {{ end }} {{ else }}
+
+      <h1>All {{ .Title }}</h1>
       {{ range .Pages.GroupByDate "2006" }}
       <h3>{{ .Key }}</h3>
       <ul>
@@ -12,7 +20,7 @@
         </li>
         {{ end }}
       </ul>
-      {{ end }}
+      {{ end }} {{ end }}
     </div>
   </div>
 </div>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -2,10 +2,16 @@
 <div class="container">
   <div class="row">
     <div>
-      {{ range .Pages }}
-      <h3>
-        <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
-      </h3>
+      <h1>View All {{ .Title }} Posts</h1>
+      {{ range .Pages.GroupByDate "2006" }}
+      <h3>{{ .Key }}</h3>
+      <ul>
+        {{ range .Pages }}
+        <li>
+          <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+        </li>
+        {{ end }}
+      </ul>
       {{ end }}
     </div>
   </div>


### PR DESCRIPTION
I've realised that we always point our speakers [hckr.cc/archive](https://hckr.cc/archive) for past talks, but it did not include anything for FH.

A while back I realised that Hugo generates a [categories page (view the old one here)](https://www.nushackers.org/categories/), and there is one for [Friday Hacks](https://www.nushackers.org/categories/friday-hacks/), but it was not maintained. 

Hence, I added Categories tag in the front matter of all past Friday Hacks, and sorted the entries by past posts by date to make this:

New Friday Hacks Category Page 
<img width="2250" height="2020" alt="Friday Hacks Category Page" src="https://github.com/user-attachments/assets/b0c79aa7-4c82-4659-b9c7-1f7063e2035c" />

All Categories Page (We can/ should maintain this?)
<img width="2250" height="1738" alt="All Categories Page" src="https://github.com/user-attachments/assets/8db9dbff-18c9-4ac4-b280-a06e93daeb4f" />

