### PR TITLE
FH Script update: Use requirements.txt for pip install

### DIFF
--- a/.github/workflows/fh_updater.yml
+++ b/.github/workflows/fh_updater.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install dependencies
-        run: pip install pyyaml
+        run: pip install -r scripts/requirements.txt
 
       - name: Run add_fh_details script
         env:


### PR DESCRIPTION
Noticed that we were still installing just `pyyaml`, but we should instead be installing all the requirements. Fixed this in the workflow.